### PR TITLE
Add admin interface for managing pricing

### DIFF
--- a/backend/data/pricing.json
+++ b/backend/data/pricing.json
@@ -1,0 +1,19 @@
+{
+  "basePrice": 35000,
+  "tramoPromotions": [
+    {
+      "id": "tramo-inicial",
+      "nombre": "Aeropuerto - Centro",
+      "descripcion": "Tarifa especial para viajes entre el aeropuerto y el centro de Temuco.",
+      "precio": 35000
+    }
+  ],
+  "dayPromotions": [
+    {
+      "id": "promo-fin-semana",
+      "dia": "Fin de semana",
+      "descripcion": "10% de descuento para viajes realizados los sábados y domingos.",
+      "descuento": 10
+    }
+  ]
+}

--- a/backend/data/pricing.json
+++ b/backend/data/pricing.json
@@ -1,44 +1,72 @@
 {
   "destinos": [
     {
-      "nombre": "pam",
-      "descripcion": "dfsdf",
-      "tiempo": "",
-      "imagen": "URL_de_imagen_por_defecto.jpg",
+      "nombre": "Temuco",
+      "descripcion": "Centro comercial y administrativo de La Araucanía.",
+      "tiempo": "45 min",
+      "imagen": "/src/assets/temuco.jpg",
       "maxPasajeros": 4,
       "minHorasAnticipacion": 5,
       "precios": {
         "auto": {
-          "base": 23235,
+          "base": 25000,
           "porcentajeAdicional": 0.1
         },
         "van": {
-          "base": 3445646,
-          "porcentajeAdicional": 0.05
+          "base": 45000,
+          "porcentajeAdicional": 0.1
         }
-      },
-      "id": "dest-1759066488691"
+      }
     },
     {
-      "nombre": "sdfds",
-      "descripcion": "xfsd",
-      "tiempo": "",
-      "imagen": "URL_de_imagen_por_defecto.jpg",
-      "maxPasajeros": 5,
+      "nombre": "Villarrica",
+      "descripcion": "Turismo y naturaleza junto al lago.",
+      "tiempo": "1h 15min",
+      "imagen": "/src/assets/villarrica.jpg",
+      "maxPasajeros": 7,
       "minHorasAnticipacion": 5,
       "precios": {
         "auto": {
-          "base": 5,
-          "porcentajeAdicional": 0.1
+          "base": 55000,
+          "porcentajeAdicional": 0.05
         },
         "van": {
-          "base": 5,
+          "base": 200000,
           "porcentajeAdicional": 0.05
         }
-      },
-      "id": "dest-1759075231687"
+      }
+    },
+    {
+      "nombre": "Pucón",
+      "descripcion": "Aventura, termas y volcán.",
+      "tiempo": "1h 30min",
+      "imagen": "/src/assets/pucon.jpg",
+      "maxPasajeros": 7,
+      "minHorasAnticipacion": 5,
+      "precios": {
+        "auto": {
+          "base": 60000,
+          "porcentajeAdicional": 0.05
+        },
+        "van": {
+          "base": 250000,
+          "porcentajeAdicional": 0.05
+        }
+      }
     }
   ],
-  "dayPromotions": [],
-  "updatedAt": "2025-09-28T16:17:42.128Z"
+  "dayPromotions": [
+    {
+      "id": "promo-1759088776861-ng5y28",
+      "destino": "Temuco",
+      "descripcion": "finde",
+      "aplicaPorDias": false,
+      "dias": [],
+      "aplicaPorHorario": false,
+      "horaInicio": "",
+      "horaFin": "",
+      "descuentoPorcentaje": 3
+    }
+  ],
+  "updatedAt": "2025-09-28T20:19:55.660Z"
 }

--- a/backend/data/pricing.json
+++ b/backend/data/pricing.json
@@ -1,58 +1,44 @@
 {
   "destinos": [
     {
-      "nombre": "Temuco",
-      "descripcion": "Centro comercial y administrativo de La Araucanía.",
-      "tiempo": "45 min",
-      "imagen": "/src/assets/temuco.jpg",
-      "maxPasajeros": 4,
+      "nombre": "pam",
+      "descripcion": "dfsdf",
+      "tiempo": "",
+      "imagen": "URL_de_imagen_por_defecto.jpg",
+      "maxPasajeros": 2,
       "minHorasAnticipacion": 5,
       "precios": {
         "auto": {
-          "base": 2000086,
+          "base": 23235,
           "porcentajeAdicional": 0.1
+        },
+        "van": {
+          "base": 3445646,
+          "porcentajeAdicional": 0.05
         }
-      }
+      },
+      "id": "dest-1759066488691"
     },
     {
-      "nombre": "Coñaripe",
-      "descripcion": "lsdfjdslfkj",
-      "tiempo": "2h",
+      "nombre": "sdfds",
+      "descripcion": "xfsd",
+      "tiempo": "",
       "imagen": "URL_de_imagen_por_defecto.jpg",
       "maxPasajeros": 4,
       "minHorasAnticipacion": 5,
       "precios": {
         "auto": {
-          "base": 70000,
+          "base": 5,
           "porcentajeAdicional": 0.1
         },
         "van": {
-          "base": 509867677,
+          "base": 5,
           "porcentajeAdicional": 0.05
         }
       },
-      "id": "dest-1759064230201"
-    },
-    {
-      "nombre": "lican",
-      "descripcion": "edf",
-      "tiempo": "1h",
-      "imagen": "URL_de_imagen_por_defecto.jpg",
-      "maxPasajeros": 7,
-      "minHorasAnticipacion": 5,
-      "precios": {
-        "auto": {
-          "base": 50000,
-          "porcentajeAdicional": 0.1
-        },
-        "van": {
-          "base": 100000,
-          "porcentajeAdicional": 0.05
-        }
-      },
-      "id": "dest-1759065359929"
+      "id": "dest-1759075231687"
     }
   ],
   "dayPromotions": [],
-  "updatedAt": "2025-09-28T13:16:02.595Z"
+  "updatedAt": "2025-09-28T16:00:32.727Z"
 }

--- a/backend/data/pricing.json
+++ b/backend/data/pricing.json
@@ -5,7 +5,7 @@
       "descripcion": "dfsdf",
       "tiempo": "",
       "imagen": "URL_de_imagen_por_defecto.jpg",
-      "maxPasajeros": 2,
+      "maxPasajeros": 4,
       "minHorasAnticipacion": 5,
       "precios": {
         "auto": {
@@ -24,7 +24,7 @@
       "descripcion": "xfsd",
       "tiempo": "",
       "imagen": "URL_de_imagen_por_defecto.jpg",
-      "maxPasajeros": 4,
+      "maxPasajeros": 5,
       "minHorasAnticipacion": 5,
       "precios": {
         "auto": {
@@ -40,5 +40,5 @@
     }
   ],
   "dayPromotions": [],
-  "updatedAt": "2025-09-28T16:00:32.727Z"
+  "updatedAt": "2025-09-28T16:17:42.128Z"
 }

--- a/backend/data/pricing.json
+++ b/backend/data/pricing.json
@@ -1,19 +1,56 @@
 {
-  "basePrice": 35000,
-  "tramoPromotions": [
+  "destinos": [
     {
-      "id": "tramo-inicial",
-      "nombre": "Aeropuerto - Centro",
-      "descripcion": "Tarifa especial para viajes entre el aeropuerto y el centro de Temuco.",
-      "precio": 35000
+      "nombre": "Temuco",
+      "descripcion": "Centro comercial y administrativo de La Araucanía.",
+      "tiempo": "45 min",
+      "imagen": "/src/assets/temuco.jpg",
+      "maxPasajeros": 4,
+      "minHorasAnticipacion": 5,
+      "precios": {
+        "auto": {
+          "base": 200000,
+          "porcentajeAdicional": 0.1
+        }
+      }
+    },
+    {
+      "nombre": "Villarrica",
+      "descripcion": "Turismo y naturaleza junto al lago.",
+      "tiempo": "1h 15min",
+      "imagen": "/src/assets/villarrica.jpg",
+      "maxPasajeros": 7,
+      "minHorasAnticipacion": 5,
+      "precios": {
+        "auto": {
+          "base": 55000,
+          "porcentajeAdicional": 0.05
+        },
+        "van": {
+          "base": 200000,
+          "porcentajeAdicional": 0.05
+        }
+      }
+    },
+    {
+      "nombre": "Pucón",
+      "descripcion": "Aventura, termas y volcán.",
+      "tiempo": "1h 30min",
+      "imagen": "/src/assets/pucon.jpg",
+      "maxPasajeros": 7,
+      "minHorasAnticipacion": 5,
+      "precios": {
+        "auto": {
+          "base": 60000,
+          "porcentajeAdicional": 0.05
+        },
+        "van": {
+          "base": 250000,
+          "porcentajeAdicional": 0.05
+        }
+      }
     }
   ],
-  "dayPromotions": [
-    {
-      "id": "promo-fin-semana",
-      "dia": "Fin de semana",
-      "descripcion": "10% de descuento para viajes realizados los sábados y domingos.",
-      "descuento": 10
-    }
-  ]
+  "dayPromotions": [],
+  "updatedAt": "2025-09-27T14:26:28.516Z"
 }

--- a/backend/data/pricing.json
+++ b/backend/data/pricing.json
@@ -9,48 +9,50 @@
       "minHorasAnticipacion": 5,
       "precios": {
         "auto": {
-          "base": 200000,
+          "base": 2000086,
           "porcentajeAdicional": 0.1
         }
       }
     },
     {
-      "nombre": "Villarrica",
-      "descripcion": "Turismo y naturaleza junto al lago.",
-      "tiempo": "1h 15min",
-      "imagen": "/src/assets/villarrica.jpg",
-      "maxPasajeros": 7,
+      "nombre": "Coñaripe",
+      "descripcion": "lsdfjdslfkj",
+      "tiempo": "2h",
+      "imagen": "URL_de_imagen_por_defecto.jpg",
+      "maxPasajeros": 4,
       "minHorasAnticipacion": 5,
       "precios": {
         "auto": {
-          "base": 55000,
-          "porcentajeAdicional": 0.05
+          "base": 70000,
+          "porcentajeAdicional": 0.1
         },
         "van": {
-          "base": 200000,
+          "base": 509867677,
           "porcentajeAdicional": 0.05
         }
-      }
+      },
+      "id": "dest-1759064230201"
     },
     {
-      "nombre": "Pucón",
-      "descripcion": "Aventura, termas y volcán.",
-      "tiempo": "1h 30min",
-      "imagen": "/src/assets/pucon.jpg",
+      "nombre": "lican",
+      "descripcion": "edf",
+      "tiempo": "1h",
+      "imagen": "URL_de_imagen_por_defecto.jpg",
       "maxPasajeros": 7,
       "minHorasAnticipacion": 5,
       "precios": {
         "auto": {
-          "base": 60000,
-          "porcentajeAdicional": 0.05
+          "base": 50000,
+          "porcentajeAdicional": 0.1
         },
         "van": {
-          "base": 250000,
+          "base": 100000,
           "porcentajeAdicional": 0.05
         }
-      }
+      },
+      "id": "dest-1759065359929"
     }
   ],
   "dayPromotions": [],
-  "updatedAt": "2025-09-27T14:26:28.516Z"
+  "updatedAt": "2025-09-28T13:16:02.595Z"
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process */
 // backend/server.js
 import express from "express";
 import cors from "cors";
@@ -5,6 +7,9 @@ import dotenv from "dotenv";
 import { MercadoPagoConfig, Preference } from "mercadopago";
 import axios from "axios";
 import crypto from "crypto";
+import { access, mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
 
 dotenv.config();
 
@@ -27,6 +32,104 @@ const signParams = (params) => {
 const app = express();
 app.use(express.json());
 app.use(cors());
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DATA_DIR = path.join(__dirname, "data");
+const PRICING_FILE_PATH = path.join(DATA_DIR, "pricing.json");
+
+const defaultPricing = {
+        basePrice: 35000,
+        tramoPromotions: [],
+        dayPromotions: [],
+        updatedAt: new Date().toISOString(),
+};
+
+const ensurePricingFile = async () => {
+        try {
+                await access(PRICING_FILE_PATH);
+        } catch {
+                await mkdir(DATA_DIR, { recursive: true });
+                await writeFile(PRICING_FILE_PATH, JSON.stringify(defaultPricing, null, 2), "utf-8");
+        }
+};
+
+const readPricingData = async () => {
+        await ensurePricingFile();
+        const fileContents = await readFile(PRICING_FILE_PATH, "utf-8");
+        try {
+                return JSON.parse(fileContents);
+        } catch (error) {
+                console.error("No se pudo parsear pricing.json, usando valores por defecto.", error);
+                return { ...defaultPricing, updatedAt: new Date().toISOString() };
+        }
+};
+
+const writePricingData = async (data) => {
+        await mkdir(DATA_DIR, { recursive: true });
+        const payload = {
+                ...data,
+                updatedAt: new Date().toISOString(),
+        };
+        await writeFile(PRICING_FILE_PATH, JSON.stringify(payload, null, 2), "utf-8");
+        return payload;
+};
+
+app.get("/pricing", async (req, res) => {
+        try {
+                const pricing = await readPricingData();
+                res.json(pricing);
+        } catch (error) {
+                console.error("Error al obtener la información de precios:", error);
+                res.status(500).json({ message: "No se pudo obtener la configuración de precios." });
+        }
+});
+
+app.put("/pricing", async (req, res) => {
+        const { basePrice, tramoPromotions, dayPromotions } = req.body || {};
+
+        const errors = [];
+
+        if (typeof basePrice !== "number" || Number.isNaN(basePrice) || basePrice < 0) {
+                errors.push("El precio base debe ser un número mayor o igual a cero.");
+        }
+
+        if (!Array.isArray(tramoPromotions)) {
+                errors.push("Las promociones por tramo deben ser un arreglo.");
+        } else if (
+                tramoPromotions.some(
+                        (promo) => typeof promo !== "object" || promo === null || typeof promo.id !== "string"
+                )
+        ) {
+                errors.push(
+                        "Cada promoción por tramo debe incluir al menos un identificador (id) y ser un objeto válido."
+                );
+        }
+
+        if (!Array.isArray(dayPromotions)) {
+                errors.push("Las promociones por día deben ser un arreglo.");
+        } else if (
+                dayPromotions.some(
+                        (promo) => typeof promo !== "object" || promo === null || typeof promo.id !== "string"
+                )
+        ) {
+                errors.push(
+                        "Cada promoción por día debe incluir al menos un identificador (id) y ser un objeto válido."
+                );
+        }
+
+        if (errors.length > 0) {
+                return res.status(400).json({ message: "Datos inválidos para la configuración de precios.", errors });
+        }
+
+        try {
+                const savedData = await writePricingData({ basePrice, tramoPromotions, dayPromotions });
+                res.json(savedData);
+        } catch (error) {
+                console.error("Error al guardar la configuración de precios:", error);
+                res.status(500).json({ message: "No se pudo guardar la configuración de precios." });
+        }
+});
 
 // --- ENDPOINT PARA CREAR PAGOS ---
 app.post("/create-payment", async (req, res) => {

--- a/env.local
+++ b/env.local
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8080

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
-// Archivo corregido: src/App.jsx
+// src/App.jsx
 
 /* global gtag */
 import "./App.css";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 
 // Componentes de la interfaz de usuario y Dialog
 import {
@@ -18,7 +18,7 @@ import { Button } from "./components/ui/button";
 import { Checkbox } from "./components/ui/checkbox";
 import { LoaderCircle } from "lucide-react";
 
-// Importar nuevos componentes de sección
+// Importar componentes de sección
 import Header from "./components/Header";
 import Hero from "./components/Hero";
 import Servicios from "./components/Servicios";
@@ -31,122 +31,33 @@ import Footer from "./components/Footer";
 import Fidelizacion from "./components/Fidelizacion";
 import AdminPricing from "./components/AdminPricing";
 
-// Importar imágenes
-import temucoImg from "./assets/temuco.jpg";
-import villarricaImg from "./assets/villarrica.jpg";
-import puconImg from "./assets/pucon.jpg";
-import corralcoImg from "./assets/corralco.jpg";
+// Corregido: Importar datos desde el archivo centralizado
+import {
+	destinosBase,
+	todosLosTramos,
+	origenesContacto,
+	destacadosData,
+} from "./data/destinos";
 
-// --- DATOS Y LÓGICA ---
-
-const destinosBase = [
-	{
-		nombre: "Temuco",
-		descripcion: "Centro comercial y administrativo de La Araucanía.",
-		tiempo: "45 min",
-		imagen: temucoImg,
-		maxPasajeros: 4,
-		minHorasAnticipacion: 5,
-		precios: {
-			auto: { base: 20000, porcentajeAdicional: 0.1 },
-		},
-	},
-	{
-		nombre: "Villarrica",
-		descripcion: "Turismo y naturaleza junto al lago.",
-		tiempo: "1h 15min",
-		imagen: villarricaImg,
-		maxPasajeros: 7,
-		minHorasAnticipacion: 5,
-		precios: {
-			auto: { base: 55000, porcentajeAdicional: 0.05 },
-			van: { base: 200000, porcentajeAdicional: 0.05 },
-		},
-	},
-	{
-		nombre: "Pucón",
-		descripcion: "Aventura, termas y volcán.",
-		tiempo: "1h 30min",
-		imagen: puconImg,
-		maxPasajeros: 7,
-		minHorasAnticipacion: 5,
-		precios: {
-			auto: { base: 60000, porcentajeAdicional: 0.05 },
-			van: { base: 250000, porcentajeAdicional: 0.05 },
-		},
-	},
-];
-
-const todosLosTramos = [
-	"Aeropuerto La Araucanía",
-	...destinosBase.map((d) => d.nombre),
-];
-const origenesContacto = ["Aeropuerto La Araucanía", "Otro"];
-
-const destacadosData = [
-	{
-		nombre: "Corralco",
-		titulo: "Visita Corralco en Temporada de Nieve",
-		subtitulo: "Una Aventura Invernal Inolvidable",
-		descripcion:
-			"Disfruta de la majestuosa nieve en el centro de ski Corralco, a los pies del volcán Lonquimay. Ofrecemos traslados directos y seguros para que solo te preocupes de disfrutar las pistas y los paisajes.",
-		imagen: corralcoImg,
-	},
-];
-
-const calcularCotizacion = (origen, destino, pasajeros) => {
-	const tramo = [origen, destino].find(
-		(lugar) => lugar !== "Aeropuerto La Araucanía"
-	);
-	const destinoInfo = destinosBase.find((d) => d.nombre === tramo);
-
-	if (!origen || !destinoInfo || !pasajeros || destino === "Otro") {
-		return { precio: null, vehiculo: null };
-	}
-
-	const numPasajeros = parseInt(pasajeros);
-	let vehiculoAsignado;
-	let precioFinal;
-
-	if (numPasajeros > 0 && numPasajeros <= 4) {
-		vehiculoAsignado = "Auto Privado";
-		const precios = destinoInfo.precios.auto;
-		if (!precios) return { precio: null, vehiculo: vehiculoAsignado };
-
-		const pasajerosAdicionales = numPasajeros - 1;
-		const costoAdicional = precios.base * precios.porcentajeAdicional;
-		precioFinal = precios.base + pasajerosAdicionales * costoAdicional;
-	} else if (numPasajeros >= 5 && numPasajeros <= 7) {
-		vehiculoAsignado = "Van de Pasajeros";
-		const precios = destinoInfo.precios.van;
-		if (!precios) return { precio: null, vehiculo: vehiculoAsignado };
-
-		const pasajerosAdicionales = numPasajeros - 5;
-		const costoAdicional = precios.base * precios.porcentajeAdicional;
-		precioFinal = precios.base + pasajerosAdicionales * costoAdicional;
-	} else {
-		vehiculoAsignado = "Consultar disponibilidad";
-		precioFinal = null;
-	}
-
-	return { precio: Math.round(precioFinal), vehiculo: vehiculoAsignado };
-};
+// --- LÓGICA ---
 
 const DESCUENTO_ONLINE = 0.1;
 
 const resolveIsAdminView = () => {
-        if (typeof window === "undefined") {
-                return false;
-        }
-
-        return window.location.pathname.toLowerCase().startsWith("/admin/precios");
+	if (typeof window === "undefined") {
+		return false;
+	}
+	return window.location.pathname.toLowerCase().startsWith("/admin/precios");
 };
 
 function App() {
-        const [isAdminView, setIsAdminView] = useState(() => resolveIsAdminView());
-        const [formData, setFormData] = useState({
-                nombre: "",
-                telefono: "",
+	const [isAdminView, setIsAdminView] = useState(() => resolveIsAdminView());
+	const [destinosData, setDestinosData] = useState(destinosBase);
+	const [loadingPrecios, setLoadingPrecios] = useState(true);
+
+	const [formData, setFormData] = useState({
+		nombre: "",
+		telefono: "",
 		email: "",
 		origen: "Aeropuerto La Araucanía",
 		otroOrigen: "",
@@ -170,33 +81,105 @@ function App() {
 	});
 	const [loadingGateway, setLoadingGateway] = useState(null);
 
-        const destinosDisponibles = useMemo(() => {
-                return todosLosTramos.filter((d) => d !== formData.origen);
-        }, [formData.origen]);
+	useEffect(() => {
+		const fetchPreciosDesdeAPI = async () => {
+			try {
+				const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:8080";
+				const response = await fetch(`${apiUrl}/pricing`);
+				if (!response.ok) {
+					throw new Error("Respuesta de red no fue exitosa.");
+				}
+				const data = await response.json();
 
-        useEffect(() => {
-                if (typeof window === "undefined") {
-                        return undefined;
-                }
+				if (data.destinos && data.destinos.length > 0) {
+					const synchronizedDestinos = destinosBase.map((baseDest) => {
+						const savedDest = data.destinos.find(
+							(d) => d.nombre === baseDest.nombre
+						);
+						// Fusiona los precios guardados con la estructura base
+						return savedDest
+							? { ...baseDest, precios: savedDest.precios }
+							: baseDest;
+					});
+					setDestinosData(synchronizedDestinos);
+				}
+			} catch (error) {
+				console.error(
+					"Error al cargar precios desde la API, usando valores por defecto.",
+					error
+				);
+				setDestinosData(destinosBase);
+			} finally {
+				setLoadingPrecios(false);
+			}
+		};
+		fetchPreciosDesdeAPI();
+	}, []);
 
-                const handleLocationChange = () => {
-                        setIsAdminView(resolveIsAdminView());
-                };
+	const calcularCotizacion = useCallback(
+		(origen, destino, pasajeros) => {
+			const tramo = [origen, destino].find(
+				(lugar) => lugar !== "Aeropuerto La Araucanía"
+			);
+			const destinoInfo = destinosData.find((d) => d.nombre === tramo);
 
-                window.addEventListener("popstate", handleLocationChange);
+			if (!origen || !destinoInfo || !pasajeros || destino === "Otro") {
+				return { precio: null, vehiculo: null };
+			}
 
-                return () => {
-                        window.removeEventListener("popstate", handleLocationChange);
-                };
-        }, []);
+			const numPasajeros = parseInt(pasajeros);
+			let vehiculoAsignado;
+			let precioFinal;
 
-        const cotizacion = useMemo(() => {
-                return calcularCotizacion(
+			if (numPasajeros > 0 && numPasajeros <= 4) {
+				vehiculoAsignado = "Auto Privado";
+				const precios = destinoInfo.precios.auto;
+				if (!precios) return { precio: null, vehiculo: vehiculoAsignado };
+				const pasajerosAdicionales = numPasajeros - 1;
+				const costoAdicional = precios.base * precios.porcentajeAdicional;
+				precioFinal = precios.base + pasajerosAdicionales * costoAdicional;
+			} else if (numPasajeros >= 5 && numPasajeros <= 7) {
+				vehiculoAsignado = "Van de Pasajeros";
+				const precios = destinoInfo.precios.van;
+				if (!precios) return { precio: null, vehiculo: vehiculoAsignado };
+				const pasajerosAdicionales = numPasajeros - 5;
+				const costoAdicional = precios.base * precios.porcentajeAdicional;
+				precioFinal = precios.base + pasajerosAdicionales * costoAdicional;
+			} else {
+				vehiculoAsignado = "Consultar disponibilidad";
+				precioFinal = null;
+			}
+			return { precio: Math.round(precioFinal), vehiculo: vehiculoAsignado };
+		},
+		[destinosData]
+	);
+
+	const destinosDisponibles = useMemo(() => {
+		return todosLosTramos.filter((d) => d !== formData.origen);
+	}, [formData.origen]);
+
+	useEffect(() => {
+		const handleLocationChange = () => {
+			setIsAdminView(resolveIsAdminView());
+		};
+		window.addEventListener("popstate", handleLocationChange);
+		return () => {
+			window.removeEventListener("popstate", handleLocationChange);
+		};
+	}, []);
+
+	const cotizacion = useMemo(() => {
+		return calcularCotizacion(
 			formData.origen,
 			formData.destino,
 			formData.pasajeros
 		);
-	}, [formData.origen, formData.destino, formData.pasajeros]);
+	}, [
+		formData.origen,
+		formData.destino,
+		formData.pasajeros,
+		calcularCotizacion,
+	]);
 
 	const validarTelefono = (telefono) => {
 		const regex = /^(\+?56)?(\s?9)\s?(\d{4})\s?(\d{4})$/;
@@ -204,7 +187,7 @@ function App() {
 	};
 
 	const validarHorarioReserva = () => {
-		const destinoSeleccionado = destinosBase.find(
+		const destinoSeleccionado = destinosData.find(
 			(d) => d.nombre === formData.destino
 		);
 		if (!destinoSeleccionado || !formData.fecha || !formData.hora) {
@@ -213,20 +196,16 @@ function App() {
 				mensaje: "Por favor, completa la fecha y hora.",
 			};
 		}
-
 		const ahora = new Date();
 		const fechaReserva = new Date(`${formData.fecha}T${formData.hora}`);
 		const horasDeDiferencia = (fechaReserva - ahora) / (1000 * 60 * 60);
-
 		const { minHorasAnticipacion } = destinoSeleccionado;
-
 		if (horasDeDiferencia < minHorasAnticipacion) {
 			return {
 				esValido: false,
 				mensaje: `Para ${destinoSeleccionado.nombre}, por favor reserva con al menos ${minHorasAnticipacion} horas de anticipación.`,
 			};
 		}
-
 		return { esValido: true, mensaje: "" };
 	};
 
@@ -234,35 +213,30 @@ function App() {
 		const { name, value } = e.target;
 		setFormData((prev) => {
 			const newFormData = { ...prev, [name]: value };
-
 			if (name === "origen" && value !== "Aeropuerto La Araucanía") {
 				newFormData.destino = "Aeropuerto La Araucanía";
 			} else if (name === "destino" && value !== "Aeropuerto La Araucanía") {
 				newFormData.origen = "Aeropuerto La Araucanía";
 			}
-
 			return newFormData;
 		});
-
-		if (name === "telefono") {
-			setPhoneError("");
-		}
+		if (name === "telefono") setPhoneError("");
 	};
 
-        useEffect(() => {
-                const destinoSeleccionado = destinosBase.find(
-                        (d) => d.nombre === formData.destino
-                );
+	useEffect(() => {
+		const destinoSeleccionado = destinosData.find(
+			(d) => d.nombre === formData.destino
+		);
 		if (
 			destinoSeleccionado &&
 			parseInt(formData.pasajeros) > destinoSeleccionado.maxPasajeros
 		) {
 			setFormData((prev) => ({ ...prev, pasajeros: "1" }));
 		}
-	}, [formData.destino, formData.pasajeros]);
+	}, [formData.destino, formData.pasajeros, destinosData]);
 
-        const resetForm = () => {
-                setFormData({
+	const resetForm = () => {
+		setFormData({
 			nombre: "",
 			telefono: "",
 			email: "",
@@ -281,25 +255,44 @@ function App() {
 		});
 	};
 
-        const handleCloseAlert = () => {
-                setShowConfirmationAlert(false);
-                setReviewChecklist({ viaje: false, contacto: false });
-                resetForm();
-        };
+	const handleCloseAlert = () => {
+		setShowConfirmationAlert(false);
+		setReviewChecklist({ viaje: false, contacto: false });
+		resetForm();
+	};
 
-        const handlePayment = async (gateway, type = "abono") => {
+	const pricing = useMemo(() => {
+		const precioBase = cotizacion.precio || 0;
+		const descuentoOnline = Math.round(precioBase * DESCUENTO_ONLINE);
+		const totalConDescuento = Math.max(precioBase - descuentoOnline, 0);
+		const abono = Math.round(totalConDescuento * 0.4);
+		const saldoPendiente = Math.max(totalConDescuento - abono, 0);
+		return {
+			precioBase,
+			descuentoOnline,
+			totalConDescuento,
+			abono,
+			saldoPendiente,
+		};
+	}, [cotizacion.precio]);
+
+	const {
+		precioBase,
+		descuentoOnline,
+		totalConDescuento,
+		abono,
+		saldoPendiente,
+	} = pricing;
+
+	const handlePayment = async (gateway, type = "abono") => {
 		setLoadingGateway(`${gateway}-${type}`);
-
 		const destinoFinal =
 			formData.destino === "Otro" ? formData.otroDestino : formData.destino;
 		const { vehiculo } = cotizacion;
-
 		const amount = type === "total" ? totalConDescuento : abono;
 
 		if (!amount) {
-			alert(
-				"Aún no tenemos un valor disponible para generar el enlace de pago. Por favor, revisa tu cotización o contáctanos."
-			);
+			alert("Aún no tenemos un valor para generar el enlace de pago.");
 			setLoadingGateway(null);
 			return;
 		}
@@ -307,15 +300,13 @@ function App() {
 		const description =
 			type === "total"
 				? `Pago total con descuento para ${destinoFinal} (${
-						vehiculo || "Vehículo a confirmar"
+						vehiculo || "A confirmar"
 				  })`
 				: `Abono reserva (40%) para ${destinoFinal} (${
-						vehiculo || "Vehículo a confirmar"
+						vehiculo || "A confirmar"
 				  })`;
 
-		const apiUrl =
-			import.meta.env.VITE_API_URL ||
-			"https://transportes-araucaria.onrender.com";
+		const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:8080";
 
 		try {
 			const response = await fetch(`${apiUrl}/create-payment`, {
@@ -338,7 +329,7 @@ function App() {
 			}
 		} catch (error) {
 			console.error("Error al crear el pago:", error);
-			alert(`Hubo un problema al generar el enlace de pago: ${error.message}`);
+			alert(`Hubo un problema: ${error.message}`);
 		} finally {
 			setLoadingGateway(null);
 		}
@@ -347,7 +338,7 @@ function App() {
 	const enviarReserva = async (source) => {
 		if (!validarTelefono(formData.telefono)) {
 			setPhoneError(
-				"Por favor, introduce un número de móvil chileno válido (ej: +56 9 1234 5678)."
+				"Introduce un número de móvil chileno válido (ej: +56 9 1234 5678)."
 			);
 			return { success: false, error: "telefono" };
 		}
@@ -358,15 +349,11 @@ function App() {
 			return { success: false, error: "horario", message: validacion.mensaje };
 		}
 
-		if (isSubmitting) {
-			return { success: false, error: "procesando" };
-		}
+		if (isSubmitting) return { success: false, error: "procesando" };
 
 		setIsSubmitting(true);
-
 		const destinoFinal =
 			formData.destino === "Otro" ? formData.otroDestino : formData.destino;
-
 		const origenFinal =
 			formData.origen === "Otro" ? formData.otroOrigen : formData.origen;
 
@@ -395,21 +382,17 @@ function App() {
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(dataToSend),
 			});
-
 			const result = await response.json();
 			if (!response.ok) {
 				throw new Error(result.message || "Error en el servidor PHP.");
 			}
-
 			setReviewChecklist({ viaje: false, contacto: false });
 			setShowConfirmationAlert(true);
-
 			if (typeof gtag === "function") {
 				gtag("event", "conversion", {
 					send_to: `AW-17529712870/8GVlCLP-05MbEObh6KZB`,
 				});
 			}
-
 			return { success: true };
 		} catch (error) {
 			console.error("Error al enviar el formulario a PHP:", error);
@@ -425,16 +408,11 @@ function App() {
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
-		const result = await enviarReserva(
-			"Formulario de Contacto - Transportes Araucaria"
-		);
-
+		const result = await enviarReserva("Formulario de Contacto");
 		if (!result.success) {
-			if (result.error === "horario" && result.message) {
-				alert(result.message);
-			} else if (result.error === "server" && result.message) {
+			if (result.error === "horario" && result.message) alert(result.message);
+			else if (result.error === "server" && result.message)
 				alert(`Error: ${result.message}`);
-			}
 		}
 	};
 
@@ -445,25 +423,13 @@ function App() {
 			formData.destino === "Otro" ? formData.otroDestino : formData.destino;
 		const viajeInfo = `${destinoFinal} el ${formData.fecha} a las ${formData.hora}`;
 		const extras = [];
-
-		if (formData.numeroVuelo) {
-			extras.push(`Vuelo: ${formData.numeroVuelo}`);
-		}
-
-		if (formData.hotel) {
-			extras.push(`Alojamiento: ${formData.hotel}`);
-		}
-
-		if (formData.equipajeEspecial) {
+		if (formData.numeroVuelo) extras.push(`Vuelo: ${formData.numeroVuelo}`);
+		if (formData.hotel) extras.push(`Alojamiento: ${formData.hotel}`);
+		if (formData.equipajeEspecial)
 			extras.push(`Equipaje: ${formData.equipajeEspecial}`);
-		}
-
-		if (formData.sillaInfantil && formData.sillaInfantil !== "no") {
+		if (formData.sillaInfantil && formData.sillaInfantil !== "no")
 			extras.push(`Silla infantil: ${formData.sillaInfantil}`);
-		}
-
 		const detalles = extras.length ? ` Detalles: ${extras.join(" | ")}.` : "";
-
 		const message = `Hola, acabo de reservar en el sitio web. Mi nombre es ${
 			formData.nombre || "Cliente"
 		} y quisiera confirmar mi traslado a ${viajeInfo}.${detalles}`;
@@ -471,47 +437,20 @@ function App() {
 	}, [formData]);
 
 	const maxPasajeros = useMemo(() => {
-		const destino = destinosBase.find((d) => d.nombre === formData.destino);
+		const destino = destinosData.find((d) => d.nombre === formData.destino);
 		return destino?.maxPasajeros || 7;
-	}, [formData.destino]);
+	}, [formData.destino, destinosData]);
 
 	const minDateTime = useMemo(() => {
-		const destino = destinosBase.find((d) => d.nombre === formData.destino);
+		const destino = destinosData.find((d) => d.nombre === formData.destino);
 		const horasAnticipacion = destino?.minHorasAnticipacion || 5;
-
 		const fechaMinima = new Date();
 		fechaMinima.setHours(fechaMinima.getHours() + horasAnticipacion);
-
 		const anio = fechaMinima.getFullYear();
 		const mes = String(fechaMinima.getMonth() + 1).padStart(2, "0");
 		const dia = String(fechaMinima.getDate()).padStart(2, "0");
-
 		return `${anio}-${mes}-${dia}`;
-	}, [formData.destino]);
-
-	const pricing = useMemo(() => {
-		const precioBase = cotizacion.precio || 0;
-		const descuentoOnline = Math.round(precioBase * DESCUENTO_ONLINE);
-		const totalConDescuento = Math.max(precioBase - descuentoOnline, 0);
-		const abono = Math.round(totalConDescuento * 0.4);
-		const saldoPendiente = Math.max(totalConDescuento - abono, 0);
-
-		return {
-			precioBase,
-			descuentoOnline,
-			totalConDescuento,
-			abono,
-			saldoPendiente,
-		};
-	}, [cotizacion.precio]);
-
-	const {
-		precioBase,
-		descuentoOnline,
-		totalConDescuento,
-		abono,
-		saldoPendiente,
-	} = pricing;
+	}, [formData.destino, destinosData]);
 
 	const currencyFormatter = useMemo(
 		() =>
@@ -530,36 +469,40 @@ function App() {
 		formData.destino === "Otro" ? formData.otroDestino : formData.destino;
 
 	const extrasList = [];
-	if (formData.numeroVuelo) {
+	if (formData.numeroVuelo)
 		extrasList.push({ label: "Vuelo", value: formData.numeroVuelo });
-	}
-	if (formData.hotel) {
+	if (formData.hotel)
 		extrasList.push({ label: "Alojamiento", value: formData.hotel });
-	}
-	if (formData.sillaInfantil && formData.sillaInfantil !== "no") {
-		extrasList.push({ label: "Silla infantil", value: formData.sillaInfantil });
-	}
-	if (formData.equipajeEspecial) {
+	if (formData.sillaInfantil && formData.sillaInfantil !== "no")
+		extrasList.push({
+			label: "Silla infantil",
+			value: formData.sillaInfantil,
+		});
+	if (formData.equipajeEspecial)
 		extrasList.push({
 			label: "Equipaje",
 			value: formData.equipajeEspecial,
 			fullWidth: true,
 		});
+	if (formData.mensaje)
+		extrasList.push({
+			label: "Notas",
+			value: formData.mensaje,
+			fullWidth: true,
+		});
+
+	if (isAdminView) {
+		return <AdminPricing />;
 	}
-        if (formData.mensaje) {
-                extrasList.push({
-                        label: "Notas",
-                        value: formData.mensaje,
-                        fullWidth: true,
-                });
-        }
 
-        if (isAdminView) {
-                return <AdminPricing />;
-        }
-
-        return (
+	return (
 		<div className="min-h-screen bg-background text-foreground">
+			{loadingPrecios && (
+				<div className="fixed top-0 left-0 w-full h-full bg-black/50 z-[100] flex items-center justify-center text-white">
+					<LoaderCircle className="animate-spin mr-2" />
+					Cargando tarifas actualizadas...
+				</div>
+			)}
 			<Dialog
 				open={showConfirmationAlert}
 				onOpenChange={setShowConfirmationAlert}
@@ -879,7 +822,7 @@ function App() {
 					showSummary={showConfirmationAlert}
 				/>
 				<Servicios />
-				<Destinos destinos={destinosBase} />
+				<Destinos destinos={destinosData} />
 
 				<Destacados destinos={destacadosData} />
 				<Fidelizacion />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -125,20 +125,27 @@ function App() {
 	// LÓGICA CORREGIDA PARA ACTUALIZACIÓN DINÁMICA DE PASAJEROS
 	// ==================================================================
 	const destinoSeleccionado = useMemo(() => {
-		if (!formData.destino) return null;
-		return destinosData.find((d) => d.nombre === formData.destino);
-	}, [formData.destino, destinosData]);
+		const tramo = [formData.origen, formData.destino].find(
+			(lugar) =>
+				lugar &&
+				lugar !== "Aeropuerto La Araucanía" &&
+				lugar !== "Otro"
+		);
+		if (!tramo) return null;
+		return destinosData.find((d) => d.nombre === tramo) || null;
+	}, [formData.origen, formData.destino, destinosData]);
 
-	const maxPasajeros = destinoSeleccionado
-		? destinoSeleccionado.maxPasajeros
-		: 7;
+	const maxPasajeros = destinoSeleccionado?.maxPasajeros ?? 7;
 
 	useEffect(() => {
-		if (
-			destinoSeleccionado &&
-			parseInt(formData.pasajeros) > destinoSeleccionado.maxPasajeros
-		) {
-			setFormData((prev) => ({ ...prev, pasajeros: "1" }));
+		if (!destinoSeleccionado) return;
+		const limite = destinoSeleccionado.maxPasajeros;
+		const pasajerosSeleccionados = parseInt(formData.pasajeros, 10);
+		if (Number.isFinite(pasajerosSeleccionados) && pasajerosSeleccionados > limite) {
+			setFormData((prev) => ({
+				...prev,
+				pasajeros: limite.toString(),
+			}));
 		}
 	}, [destinoSeleccionado, formData.pasajeros]);
 

--- a/src/components/AdminPricing.jsx
+++ b/src/components/AdminPricing.jsx
@@ -1,475 +1,476 @@
 import { useCallback, useEffect, useState } from "react";
 
-const API_BASE_URL =
-        import.meta.env.VITE_API_URL || "https://transportes-araucaria.onrender.com";
+const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
 
 const createId = () => {
-        if (typeof crypto !== "undefined" && crypto.randomUUID) {
-                return crypto.randomUUID();
-        }
-        return `promo-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+	if (typeof crypto !== "undefined" && crypto.randomUUID) {
+		return crypto.randomUUID();
+	}
+	return `promo-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 };
 
 const defaultState = {
-        basePrice: 0,
-        tramoPromotions: [],
-        dayPromotions: [],
-        updatedAt: null,
+	basePrice: 0,
+	tramoPromotions: [],
+	dayPromotions: [],
+	updatedAt: null,
 };
 
 const daysOfWeek = [
-        "Lunes",
-        "Martes",
-        "Miércoles",
-        "Jueves",
-        "Viernes",
-        "Sábado",
-        "Domingo",
+	"Lunes",
+	"Martes",
+	"Miércoles",
+	"Jueves",
+	"Viernes",
+	"Sábado",
+	"Domingo",
 ];
 
 function AdminPricing() {
-        const [pricing, setPricing] = useState(defaultState);
-        const [loading, setLoading] = useState(true);
-        const [saving, setSaving] = useState(false);
-        const [error, setError] = useState("");
-        const [success, setSuccess] = useState("");
+	const [pricing, setPricing] = useState(defaultState);
+	const [loading, setLoading] = useState(true);
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState("");
+	const [success, setSuccess] = useState("");
 
-        const fetchPricing = useCallback(async () => {
-                setLoading(true);
-                setError("");
-                try {
-                        const response = await fetch(`${API_BASE_URL}/pricing`);
-                        if (!response.ok) {
-                                throw new Error("No se pudo obtener la configuración de precios.");
-                        }
-                        const data = await response.json();
-                        setPricing({
-                                basePrice: data.basePrice ?? 0,
-                                tramoPromotions: Array.isArray(data.tramoPromotions)
-                                        ? data.tramoPromotions
-                                        : [],
-                                dayPromotions: Array.isArray(data.dayPromotions)
-                                        ? data.dayPromotions
-                                        : [],
-                                updatedAt: data.updatedAt || null,
-                        });
-                } catch (fetchError) {
-                        console.error(fetchError);
-                        setError(
-                                fetchError.message ||
-                                        "Ocurrió un error inesperado al cargar la configuración."
-                        );
-                } finally {
-                        setLoading(false);
-                }
-        }, []);
+	const fetchPricing = useCallback(async () => {
+		setLoading(true);
+		setError("");
+		try {
+			const response = await fetch(`${API_BASE_URL}/pricing`);
+			if (!response.ok) {
+				throw new Error("No se pudo obtener la configuración de precios.");
+			}
+			const data = await response.json();
+			setPricing({
+				basePrice: data.basePrice ?? 0,
+				tramoPromotions: Array.isArray(data.tramoPromotions)
+					? data.tramoPromotions
+					: [],
+				dayPromotions: Array.isArray(data.dayPromotions)
+					? data.dayPromotions
+					: [],
+				updatedAt: data.updatedAt || null,
+			});
+		} catch (fetchError) {
+			console.error(fetchError);
+			setError(
+				fetchError.message ||
+					"Ocurrió un error inesperado al cargar la configuración."
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
 
-        useEffect(() => {
-                fetchPricing();
-        }, [fetchPricing]);
+	useEffect(() => {
+		fetchPricing();
+	}, [fetchPricing]);
 
-        useEffect(() => {
-                if (!success) return;
+	useEffect(() => {
+		if (!success) return;
 
-                const timeout = setTimeout(() => setSuccess(""), 4000);
-                return () => clearTimeout(timeout);
-        }, [success]);
+		const timeout = setTimeout(() => setSuccess(""), 4000);
+		return () => clearTimeout(timeout);
+	}, [success]);
 
-        const handleBasePriceChange = (event) => {
-                const value = Number(event.target.value);
-                setPricing((prev) => ({ ...prev, basePrice: Number.isNaN(value) ? 0 : value }));
-        };
+	const handleBasePriceChange = (event) => {
+		const value = Number(event.target.value);
+		setPricing((prev) => ({
+			...prev,
+			basePrice: Number.isNaN(value) ? 0 : value,
+		}));
+	};
 
-        const handleTramoChange = (id, field, value) => {
-                setPricing((prev) => ({
-                        ...prev,
-                        tramoPromotions: prev.tramoPromotions.map((promo) =>
-                                promo.id === id ? { ...promo, [field]: value } : promo
-                        ),
-                }));
-        };
+	const handleTramoChange = (id, field, value) => {
+		setPricing((prev) => ({
+			...prev,
+			tramoPromotions: prev.tramoPromotions.map((promo) =>
+				promo.id === id ? { ...promo, [field]: value } : promo
+			),
+		}));
+	};
 
-        const handleDayChange = (id, field, value) => {
-                setPricing((prev) => ({
-                        ...prev,
-                        dayPromotions: prev.dayPromotions.map((promo) =>
-                                promo.id === id ? { ...promo, [field]: value } : promo
-                        ),
-                }));
-        };
+	const handleDayChange = (id, field, value) => {
+		setPricing((prev) => ({
+			...prev,
+			dayPromotions: prev.dayPromotions.map((promo) =>
+				promo.id === id ? { ...promo, [field]: value } : promo
+			),
+		}));
+	};
 
-        const addTramoPromotion = () => {
-                setPricing((prev) => ({
-                        ...prev,
-                        tramoPromotions: [
-                                ...prev.tramoPromotions,
-                                {
-                                        id: createId(),
-                                        nombre: "Nuevo tramo",
-                                        descripcion: "",
-                                        precio: prev.basePrice,
-                                },
-                        ],
-                }));
-        };
+	const addTramoPromotion = () => {
+		setPricing((prev) => ({
+			...prev,
+			tramoPromotions: [
+				...prev.tramoPromotions,
+				{
+					id: createId(),
+					nombre: "Nuevo tramo",
+					descripcion: "",
+					precio: prev.basePrice,
+				},
+			],
+		}));
+	};
 
-        const addDayPromotion = () => {
-                setPricing((prev) => ({
-                        ...prev,
-                        dayPromotions: [
-                                ...prev.dayPromotions,
-                                {
-                                        id: createId(),
-                                        dia: "Lunes",
-                                        descripcion: "",
-                                        descuento: 0,
-                                },
-                        ],
-                }));
-        };
+	const addDayPromotion = () => {
+		setPricing((prev) => ({
+			...prev,
+			dayPromotions: [
+				...prev.dayPromotions,
+				{
+					id: createId(),
+					dia: "Lunes",
+					descripcion: "",
+					descuento: 0,
+				},
+			],
+		}));
+	};
 
-        const removeTramoPromotion = (id) => {
-                setPricing((prev) => ({
-                        ...prev,
-                        tramoPromotions: prev.tramoPromotions.filter((promo) => promo.id !== id),
-                }));
-        };
+	const removeTramoPromotion = (id) => {
+		setPricing((prev) => ({
+			...prev,
+			tramoPromotions: prev.tramoPromotions.filter((promo) => promo.id !== id),
+		}));
+	};
 
-        const removeDayPromotion = (id) => {
-                setPricing((prev) => ({
-                        ...prev,
-                        dayPromotions: prev.dayPromotions.filter((promo) => promo.id !== id),
-                }));
-        };
+	const removeDayPromotion = (id) => {
+		setPricing((prev) => ({
+			...prev,
+			dayPromotions: prev.dayPromotions.filter((promo) => promo.id !== id),
+		}));
+	};
 
-        const handleSubmit = async (event) => {
-                event.preventDefault();
-                setSaving(true);
-                setError("");
-                setSuccess("");
+	const handleSubmit = async (event) => {
+		event.preventDefault();
+		setSaving(true);
+		setError("");
+		setSuccess("");
 
-                try {
-                        const response = await fetch(`${API_BASE_URL}/pricing`, {
-                                method: "PUT",
-                                headers: {
-                                        "Content-Type": "application/json",
-                                },
-                                body: JSON.stringify({
-                                        basePrice: Number(pricing.basePrice) || 0,
-                                        tramoPromotions: pricing.tramoPromotions.map((promo) => ({
-                                                ...promo,
-                                                precio: Number(promo.precio) || 0,
-                                        })),
-                                        dayPromotions: pricing.dayPromotions.map((promo) => ({
-                                                ...promo,
-                                                descuento: Number(promo.descuento) || 0,
-                                        })),
-                                }),
-                        });
+		try {
+			const response = await fetch(`${API_BASE_URL}/pricing`, {
+				method: "PUT",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					basePrice: Number(pricing.basePrice) || 0,
+					tramoPromotions: pricing.tramoPromotions.map((promo) => ({
+						...promo,
+						precio: Number(promo.precio) || 0,
+					})),
+					dayPromotions: pricing.dayPromotions.map((promo) => ({
+						...promo,
+						descuento: Number(promo.descuento) || 0,
+					})),
+				}),
+			});
 
-                        if (!response.ok) {
-                                const errorBody = await response.json().catch(() => ({}));
-                                const message =
-                                        errorBody?.message ||
-                                        "No se pudo guardar la configuración de precios.";
-                                throw new Error(message);
-                        }
+			if (!response.ok) {
+				const errorBody = await response.json().catch(() => ({}));
+				const message =
+					errorBody?.message ||
+					"No se pudo guardar la configuración de precios.";
+				throw new Error(message);
+			}
 
-                        const saved = await response.json();
-                        setPricing(saved);
-                        setSuccess("Configuración guardada correctamente.");
-                } catch (submitError) {
-                        console.error(submitError);
-                        setError(submitError.message || "Ocurrió un error al guardar los cambios.");
-                } finally {
-                        setSaving(false);
-                }
-        };
+			const saved = await response.json();
+			setPricing(saved);
+			setSuccess("Configuración guardada correctamente.");
+		} catch (submitError) {
+			console.error(submitError);
+			setError(
+				submitError.message || "Ocurrió un error al guardar los cambios."
+			);
+		} finally {
+			setSaving(false);
+		}
+	};
 
-        return (
-                <div className="min-h-screen bg-slate-950 text-slate-100">
-                        <div className="mx-auto w-full max-w-5xl px-4 py-10">
-                                <header className="mb-10">
-                                        <h1 className="text-3xl font-semibold text-white">
-                                                Panel de tarifas y promociones
-                                        </h1>
-                                        <p className="mt-2 max-w-3xl text-sm text-slate-300">
-                                                Ajusta los valores base y administra promociones por tramo o por día.
-                                                Todos los cambios se guardan en el servidor para que puedan ser
-                                                consultados por otras herramientas o integraciones.
-                                        </p>
-                                        {pricing.updatedAt ? (
-                                                <p className="mt-3 text-xs text-slate-400">
-                                                        Última actualización: {" "}
-                                                        {new Date(pricing.updatedAt).toLocaleString()}
-                                                </p>
-                                        ) : null}
-                                </header>
+	return (
+		<div className="min-h-screen bg-slate-950 text-slate-100">
+			<div className="mx-auto w-full max-w-5xl px-4 py-10">
+				<header className="mb-10">
+					<h1 className="text-3xl font-semibold text-white">
+						Panel de tarifas y promociones
+					</h1>
+					<p className="mt-2 max-w-3xl text-sm text-slate-300">
+						Ajusta los valores base y administra promociones por tramo o por
+						día. Todos los cambios se guardan en el servidor para que puedan ser
+						consultados por otras herramientas o integraciones.
+					</p>
+					{pricing.updatedAt ? (
+						<p className="mt-3 text-xs text-slate-400">
+							Última actualización:{" "}
+							{new Date(pricing.updatedAt).toLocaleString()}
+						</p>
+					) : null}
+				</header>
 
-                                <form onSubmit={handleSubmit} className="space-y-10">
-                                        <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
-                                                <h2 className="text-xl font-semibold text-white">
-                                                        Precio base por defecto
-                                                </h2>
-                                                <p className="mt-2 text-sm text-slate-300">
-                                                        Define un precio base sugerido para tramos sin configuración
-                                                        específica.
-                                                </p>
-                                                <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
-                                                        <label className="text-sm text-slate-300" htmlFor="basePrice">
-                                                                Precio base (CLP)
-                                                        </label>
-                                                        <input
-                                                                id="basePrice"
-                                                                type="number"
-                                                                min="0"
-                                                                className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 sm:w-60"
-                                                                value={pricing.basePrice}
-                                                                onChange={handleBasePriceChange}
-                                                        />
-                                                </div>
-                                        </section>
+				<form onSubmit={handleSubmit} className="space-y-10">
+					<section className="rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
+						<h2 className="text-xl font-semibold text-white">
+							Precio base por defecto
+						</h2>
+						<p className="mt-2 text-sm text-slate-300">
+							Define un precio base sugerido para tramos sin configuración
+							específica.
+						</p>
+						<div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+							<label className="text-sm text-slate-300" htmlFor="basePrice">
+								Precio base (CLP)
+							</label>
+							<input
+								id="basePrice"
+								type="number"
+								min="0"
+								className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 sm:w-60"
+								value={pricing.basePrice}
+								onChange={handleBasePriceChange}
+							/>
+						</div>
+					</section>
 
-                                        <section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
-                                                <div className="flex flex-wrap items-center justify-between gap-4">
-                                                        <div>
-                                                                <h2 className="text-xl font-semibold text-white">
-                                                                        Promociones por tramo
-                                                                </h2>
-                                                                <p className="mt-2 text-sm text-slate-300">
-                                                                        Define tarifas especiales según origen/destino u
-                                                                        otros criterios.
-                                                                </p>
-                                                        </div>
-                                                        <button
-                                                                type="button"
-                                                                onClick={addTramoPromotion}
-                                                                className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60"
-                                                        >
-                                                                Añadir tramo
-                                                        </button>
-                                                </div>
+					<section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
+						<div className="flex flex-wrap items-center justify-between gap-4">
+							<div>
+								<h2 className="text-xl font-semibold text-white">
+									Promociones por tramo
+								</h2>
+								<p className="mt-2 text-sm text-slate-300">
+									Define tarifas especiales según origen/destino u otros
+									criterios.
+								</p>
+							</div>
+							<button
+								type="button"
+								onClick={addTramoPromotion}
+								className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60"
+							>
+								Añadir tramo
+							</button>
+						</div>
 
-                                                <div className="space-y-4">
-                                                        {pricing.tramoPromotions.length === 0 ? (
-                                                                <p className="text-sm text-slate-400">
-                                                                        Aún no has agregado promociones por tramo.
-                                                                </p>
-                                                        ) : (
-                                                                pricing.tramoPromotions.map((promo) => (
-                                                                        <div
-                                                                                key={promo.id}
-                                                                                className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
-                                                                        >
-                                                                                <div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4">
-                                                                                        <label className="text-sm text-slate-300">
-                                                                                                Nombre del tramo
-                                                                                                <input
-                                                                                                        type="text"
-                                                                                                        value={promo.nombre || ""}
-                                                                                                        onChange={(event) =>
-                                                                                                                handleTramoChange(
-                                                                                                                        promo.id,
-                                                                                                                        "nombre",
-                                                                                                                        event.target.value
-                                                                                                                )
-                                                                                                        }
-                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-                                                                                                />
-                                                                                        </label>
-                                                                                        <label className="text-sm text-slate-300">
-                                                                                                Precio fijo (CLP)
-                                                                                                <input
-                                                                                                        type="number"
-                                                                                                        min="0"
-                                                                                                        value={promo.precio ?? 0}
-                                                                                                        onChange={(event) =>
-                                                                                                                handleTramoChange(
-                                                                                                                        promo.id,
-                                                                                                                        "precio",
-                                                                                                                        Number(event.target.value)
-                                                                                                                )
-                                                                                                        }
-                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-                                                                                                />
-                                                                                        </label>
-                                                                                        <label className="sm:col-span-2 text-sm text-slate-300">
-                                                                                                Descripción u observaciones
-                                                                                                <textarea
-                                                                                                        value={promo.descripcion || ""}
-                                                                                                        onChange={(event) =>
-                                                                                                                handleTramoChange(
-                                                                                                                        promo.id,
-                                                                                                                        "descripcion",
-                                                                                                                        event.target.value
-                                                                                                                )
-                                                                                                        }
-                                                                                                        rows={2}
-                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-                                                                                                />
-                                                                                        </label>
-                                                                                </div>
-                                                                                <div className="mt-4 flex justify-end">
-                                                                                        <button
-                                                                                                type="button"
-                                                                                                onClick={() => removeTramoPromotion(promo.id)}
-                                                                                                className="rounded-md border border-red-400 px-3 py-1 text-xs font-semibold text-red-200 transition hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/40"
-                                                                                        >
-                                                                                                Eliminar tramo
-                                                                                        </button>
-                                                                                </div>
-                                                                        </div>
-                                                                ))
-                                                        )}
-                                                </div>
-                                        </section>
+						<div className="space-y-4">
+							{pricing.tramoPromotions.length === 0 ? (
+								<p className="text-sm text-slate-400">
+									Aún no has agregado promociones por tramo.
+								</p>
+							) : (
+								pricing.tramoPromotions.map((promo) => (
+									<div
+										key={promo.id}
+										className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
+									>
+										<div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4">
+											<label className="text-sm text-slate-300">
+												Nombre del tramo
+												<input
+													type="text"
+													value={promo.nombre || ""}
+													onChange={(event) =>
+														handleTramoChange(
+															promo.id,
+															"nombre",
+															event.target.value
+														)
+													}
+													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+												/>
+											</label>
+											<label className="text-sm text-slate-300">
+												Precio fijo (CLP)
+												<input
+													type="number"
+													min="0"
+													value={promo.precio ?? 0}
+													onChange={(event) =>
+														handleTramoChange(
+															promo.id,
+															"precio",
+															Number(event.target.value)
+														)
+													}
+													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+												/>
+											</label>
+											<label className="sm:col-span-2 text-sm text-slate-300">
+												Descripción u observaciones
+												<textarea
+													value={promo.descripcion || ""}
+													onChange={(event) =>
+														handleTramoChange(
+															promo.id,
+															"descripcion",
+															event.target.value
+														)
+													}
+													rows={2}
+													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+												/>
+											</label>
+										</div>
+										<div className="mt-4 flex justify-end">
+											<button
+												type="button"
+												onClick={() => removeTramoPromotion(promo.id)}
+												className="rounded-md border border-red-400 px-3 py-1 text-xs font-semibold text-red-200 transition hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/40"
+											>
+												Eliminar tramo
+											</button>
+										</div>
+									</div>
+								))
+							)}
+						</div>
+					</section>
 
-                                        <section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
-                                                <div className="flex flex-wrap items-center justify-between gap-4">
-                                                        <div>
-                                                                <h2 className="text-xl font-semibold text-white">
-                                                                        Promociones por día
-                                                                </h2>
-                                                                <p className="mt-2 text-sm text-slate-300">
-                                                                        Configura descuentos para días específicos de la semana o rangos.
-                                                                </p>
-                                                        </div>
-                                                        <button
-                                                                type="button"
-                                                                onClick={addDayPromotion}
-                                                                className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60"
-                                                        >
-                                                                Añadir promoción por día
-                                                        </button>
-                                                </div>
+					<section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
+						<div className="flex flex-wrap items-center justify-between gap-4">
+							<div>
+								<h2 className="text-xl font-semibold text-white">
+									Promociones por día
+								</h2>
+								<p className="mt-2 text-sm text-slate-300">
+									Configura descuentos para días específicos de la semana o
+									rangos.
+								</p>
+							</div>
+							<button
+								type="button"
+								onClick={addDayPromotion}
+								className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60"
+							>
+								Añadir promoción por día
+							</button>
+						</div>
 
-                                                <div className="space-y-4">
-                                                        {pricing.dayPromotions.length === 0 ? (
-                                                                <p className="text-sm text-slate-400">
-                                                                        No existen promociones por día configuradas.
-                                                                </p>
-                                                        ) : (
-                                                                pricing.dayPromotions.map((promo) => (
-                                                                        <div
-                                                                                key={promo.id}
-                                                                                className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
-                                                                        >
-                                                                                <div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4">
-                                                                                        <label className="text-sm text-slate-300">
-                                                                                                Día o rango
-                                                                                                <select
-                                                                                                        value={promo.dia || ""}
-                                                                                                        onChange={(event) =>
-                                                                                                                handleDayChange(
-                                                                                                                        promo.id,
-                                                                                                                        "dia",
-                                                                                                                        event.target.value
-                                                                                                                )
-                                                                                                        }
-                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-                                                                                                >
-                                                                                                        <option value="">Personalizado</option>
-                                                                                                        {daysOfWeek.map((day) => (
-                                                                                                                <option key={day} value={day}>
-                                                                                                                        {day}
-                                                                                                                </option>
-                                                                                                        ))}
-                                                                                                        <option value="Fin de semana">Fin de semana</option>
-                                                                                                        <option value="Feriados">Feriados</option>
-                                                                                                </select>
-                                                                                        </label>
-                                                                                        <label className="text-sm text-slate-300">
-                                                                                                Descuento (%)
-                                                                                                <input
-                                                                                                        type="number"
-                                                                                                        min="0"
-                                                                                                        max="100"
-                                                                                                        value={promo.descuento ?? 0}
-                                                                                                        onChange={(event) =>
-                                                                                                                handleDayChange(
-                                                                                                                        promo.id,
-                                                                                                                        "descuento",
-                                                                                                                        Number(event.target.value)
-                                                                                                                )
-                                                                                                        }
-                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-                                                                                                />
-                                                                                        </label>
-                                                                                        <label className="sm:col-span-2 text-sm text-slate-300">
-                                                                                                Detalles de la promoción
-                                                                                                <textarea
-                                                                                                        value={promo.descripcion || ""}
-                                                                                                        onChange={(event) =>
-                                                                                                                handleDayChange(
-                                                                                                                        promo.id,
-                                                                                                                        "descripcion",
-                                                                                                                        event.target.value
-                                                                                                                )
-                                                                                                        }
-                                                                                                        rows={2}
-                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-                                                                                                />
-                                                                                        </label>
-                                                                                </div>
-                                                                                <div className="mt-4 flex justify-end">
-                                                                                        <button
-                                                                                                type="button"
-                                                                                                onClick={() => removeDayPromotion(promo.id)}
-                                                                                                className="rounded-md border border-red-400 px-3 py-1 text-xs font-semibold text-red-200 transition hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/40"
-                                                                                        >
-                                                                                                Eliminar promoción
-                                                                                        </button>
-                                                                                </div>
-                                                                        </div>
-                                                                ))
-                                                        )}
-                                                </div>
-                                        </section>
+						<div className="space-y-4">
+							{pricing.dayPromotions.length === 0 ? (
+								<p className="text-sm text-slate-400">
+									No existen promociones por día configuradas.
+								</p>
+							) : (
+								pricing.dayPromotions.map((promo) => (
+									<div
+										key={promo.id}
+										className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
+									>
+										<div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4">
+											<label className="text-sm text-slate-300">
+												Día o rango
+												<select
+													value={promo.dia || ""}
+													onChange={(event) =>
+														handleDayChange(promo.id, "dia", event.target.value)
+													}
+													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+												>
+													<option value="">Personalizado</option>
+													{daysOfWeek.map((day) => (
+														<option key={day} value={day}>
+															{day}
+														</option>
+													))}
+													<option value="Fin de semana">Fin de semana</option>
+													<option value="Feriados">Feriados</option>
+												</select>
+											</label>
+											<label className="text-sm text-slate-300">
+												Descuento (%)
+												<input
+													type="number"
+													min="0"
+													max="100"
+													value={promo.descuento ?? 0}
+													onChange={(event) =>
+														handleDayChange(
+															promo.id,
+															"descuento",
+															Number(event.target.value)
+														)
+													}
+													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+												/>
+											</label>
+											<label className="sm:col-span-2 text-sm text-slate-300">
+												Detalles de la promoción
+												<textarea
+													value={promo.descripcion || ""}
+													onChange={(event) =>
+														handleDayChange(
+															promo.id,
+															"descripcion",
+															event.target.value
+														)
+													}
+													rows={2}
+													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+												/>
+											</label>
+										</div>
+										<div className="mt-4 flex justify-end">
+											<button
+												type="button"
+												onClick={() => removeDayPromotion(promo.id)}
+												className="rounded-md border border-red-400 px-3 py-1 text-xs font-semibold text-red-200 transition hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/40"
+											>
+												Eliminar promoción
+											</button>
+										</div>
+									</div>
+								))
+							)}
+						</div>
+					</section>
 
-                                        <footer className="flex flex-col gap-4 border-t border-slate-800 pt-6 sm:flex-row sm:items-center sm:justify-between">
-                                                <div className="flex items-center gap-3 text-sm">
-                                                        <button
-                                                                type="button"
-                                                                onClick={fetchPricing}
-                                                                className="rounded-md border border-slate-700 px-4 py-2 text-sm font-medium text-slate-300 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
-                                                                disabled={loading || saving}
-                                                        >
-                                                                Descartar cambios
-                                                        </button>
-                                                        <span className="text-xs text-slate-500">
-                                                                Recarga la información desde el servidor
-                                                        </span>
-                                                </div>
-                                                <button
-                                                        type="submit"
-                                                        disabled={saving || loading}
-                                                        className="inline-flex items-center justify-center gap-2 rounded-md bg-emerald-500 px-6 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-500/60"
-                                                >
-                                                        {saving ? "Guardando..." : "Guardar cambios"}
-                                                </button>
-                                        </footer>
-                                </form>
+					<footer className="flex flex-col gap-4 border-t border-slate-800 pt-6 sm:flex-row sm:items-center sm:justify-between">
+						<div className="flex items-center gap-3 text-sm">
+							<button
+								type="button"
+								onClick={fetchPricing}
+								className="rounded-md border border-slate-700 px-4 py-2 text-sm font-medium text-slate-300 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
+								disabled={loading || saving}
+							>
+								Descartar cambios
+							</button>
+							<span className="text-xs text-slate-500">
+								Recarga la información desde el servidor
+							</span>
+						</div>
+						<button
+							type="submit"
+							disabled={saving || loading}
+							className="inline-flex items-center justify-center gap-2 rounded-md bg-emerald-500 px-6 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-500/60"
+						>
+							{saving ? "Guardando..." : "Guardar cambios"}
+						</button>
+					</footer>
+				</form>
 
-                                {loading ? (
-                                        <div className="mt-6 rounded-md border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-300">
-                                                Cargando información de tarifas...
-                                        </div>
-                                ) : null}
+				{loading ? (
+					<div className="mt-6 rounded-md border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-300">
+						Cargando información de tarifas...
+					</div>
+				) : null}
 
-                                {error ? (
-                                        <div className="mt-6 rounded-md border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-200">
-                                                {error}
-                                        </div>
-                                ) : null}
+				{error ? (
+					<div className="mt-6 rounded-md border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-200">
+						{error}
+					</div>
+				) : null}
 
-                                {success ? (
-                                        <div className="mt-6 rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
-                                                {success}
-                                        </div>
-                                ) : null}
-                        </div>
-                </div>
-        );
+				{success ? (
+					<div className="mt-6 rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
+						{success}
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
 }
 
 export default AdminPricing;

--- a/src/components/AdminPricing.jsx
+++ b/src/components/AdminPricing.jsx
@@ -1,17 +1,14 @@
+// src/components/AdminPricing.jsx
+
 import { useCallback, useEffect, useState } from "react";
+// Corregido: Importamos los destinos desde el nuevo archivo de datos
+import { destinosBase as destinosIniciales } from "@/data/destinos";
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
 
-const createId = () => {
-	if (typeof crypto !== "undefined" && crypto.randomUUID) {
-		return crypto.randomUUID();
-	}
-	return `promo-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-};
-
+// Estructura de datos por defecto, ahora funciona sin error
 const defaultState = {
-	basePrice: 0,
-	tramoPromotions: [],
+	destinos: destinosIniciales,
 	dayPromotions: [],
 	updatedAt: null,
 };
@@ -24,6 +21,8 @@ const daysOfWeek = [
 	"Viernes",
 	"Sábado",
 	"Domingo",
+	"Fin de semana",
+	"Feriados",
 ];
 
 function AdminPricing() {
@@ -42,11 +41,16 @@ function AdminPricing() {
 				throw new Error("No se pudo obtener la configuración de precios.");
 			}
 			const data = await response.json();
+
+			const synchronizedDestinos = destinosIniciales.map((baseDest) => {
+				const savedDest = data.destinos?.find(
+					(d) => d.nombre === baseDest.nombre
+				);
+				return savedDest ? { ...baseDest, ...savedDest } : baseDest;
+			});
+
 			setPricing({
-				basePrice: data.basePrice ?? 0,
-				tramoPromotions: Array.isArray(data.tramoPromotions)
-					? data.tramoPromotions
-					: [],
+				destinos: synchronizedDestinos,
 				dayPromotions: Array.isArray(data.dayPromotions)
 					? data.dayPromotions
 					: [],
@@ -55,9 +59,13 @@ function AdminPricing() {
 		} catch (fetchError) {
 			console.error(fetchError);
 			setError(
-				fetchError.message ||
-					"Ocurrió un error inesperado al cargar la configuración."
+				fetchError.message || "Ocurrió un error al cargar la configuración."
 			);
+			setPricing({
+				destinos: destinosIniciales,
+				dayPromotions: [],
+				updatedAt: null,
+			});
 		} finally {
 			setLoading(false);
 		}
@@ -68,25 +76,28 @@ function AdminPricing() {
 	}, [fetchPricing]);
 
 	useEffect(() => {
-		if (!success) return;
-
-		const timeout = setTimeout(() => setSuccess(""), 4000);
-		return () => clearTimeout(timeout);
+		if (success) {
+			const timer = setTimeout(() => setSuccess(""), 4000);
+			return () => clearTimeout(timer);
+		}
 	}, [success]);
 
-	const handleBasePriceChange = (event) => {
-		const value = Number(event.target.value);
+	const handleDestinoChange = (nombre, vehiculo, field, value) => {
 		setPricing((prev) => ({
 			...prev,
-			basePrice: Number.isNaN(value) ? 0 : value,
-		}));
-	};
-
-	const handleTramoChange = (id, field, value) => {
-		setPricing((prev) => ({
-			...prev,
-			tramoPromotions: prev.tramoPromotions.map((promo) =>
-				promo.id === id ? { ...promo, [field]: value } : promo
+			destinos: prev.destinos.map((dest) =>
+				dest.nombre === nombre
+					? {
+							...dest,
+							precios: {
+								...dest.precios,
+								[vehiculo]: {
+									...dest.precios[vehiculo],
+									[field]: Number(value) || 0,
+								},
+							},
+					  }
+					: dest
 			),
 		}));
 	};
@@ -100,40 +111,18 @@ function AdminPricing() {
 		}));
 	};
 
-	const addTramoPromotion = () => {
-		setPricing((prev) => ({
-			...prev,
-			tramoPromotions: [
-				...prev.tramoPromotions,
-				{
-					id: createId(),
-					nombre: "Nuevo tramo",
-					descripcion: "",
-					precio: prev.basePrice,
-				},
-			],
-		}));
-	};
-
 	const addDayPromotion = () => {
 		setPricing((prev) => ({
 			...prev,
 			dayPromotions: [
 				...prev.dayPromotions,
 				{
-					id: createId(),
+					id: `promo-${Date.now()}`,
 					dia: "Lunes",
 					descripcion: "",
 					descuento: 0,
 				},
 			],
-		}));
-	};
-
-	const removeTramoPromotion = (id) => {
-		setPricing((prev) => ({
-			...prev,
-			tramoPromotions: prev.tramoPromotions.filter((promo) => promo.id !== id),
 		}));
 	};
 
@@ -153,15 +142,9 @@ function AdminPricing() {
 		try {
 			const response = await fetch(`${API_BASE_URL}/pricing`, {
 				method: "PUT",
-				headers: {
-					"Content-Type": "application/json",
-				},
+				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
-					basePrice: Number(pricing.basePrice) || 0,
-					tramoPromotions: pricing.tramoPromotions.map((promo) => ({
-						...promo,
-						precio: Number(promo.precio) || 0,
-					})),
+					destinos: pricing.destinos,
 					dayPromotions: pricing.dayPromotions.map((promo) => ({
 						...promo,
 						descuento: Number(promo.descuento) || 0,
@@ -171,14 +154,24 @@ function AdminPricing() {
 
 			if (!response.ok) {
 				const errorBody = await response.json().catch(() => ({}));
-				const message =
-					errorBody?.message ||
-					"No se pudo guardar la configuración de precios.";
-				throw new Error(message);
+				throw new Error(
+					errorBody.message || "No se pudo guardar la configuración."
+				);
 			}
 
-			const saved = await response.json();
-			setPricing(saved);
+			const savedData = await response.json();
+			// Re-sincronizar después de guardar para mantener la estructura completa
+			const synchronizedDestinos = destinosIniciales.map((baseDest) => {
+				const savedDest = savedData.destinos?.find(
+					(d) => d.nombre === baseDest.nombre
+				);
+				return savedDest ? { ...baseDest, ...savedDest } : baseDest;
+			});
+
+			setPricing({
+				...savedData,
+				destinos: synchronizedDestinos,
+			});
 			setSuccess("Configuración guardada correctamente.");
 		} catch (submitError) {
 			console.error(submitError);
@@ -190,141 +183,73 @@ function AdminPricing() {
 		}
 	};
 
+	if (loading) {
+		return (
+			<div className="flex h-screen items-center justify-center bg-slate-950 text-white">
+				Cargando configuración de tarifas...
+			</div>
+		);
+	}
+
 	return (
 		<div className="min-h-screen bg-slate-950 text-slate-100">
 			<div className="mx-auto w-full max-w-5xl px-4 py-10">
 				<header className="mb-10">
 					<h1 className="text-3xl font-semibold text-white">
-						Panel de tarifas y promociones
+						Panel de Tarifas y Promociones
 					</h1>
 					<p className="mt-2 max-w-3xl text-sm text-slate-300">
-						Ajusta los valores base y administra promociones por tramo o por
-						día. Todos los cambios se guardan en el servidor para que puedan ser
-						consultados por otras herramientas o integraciones.
+						Administra las tarifas base para cada destino y vehículo. Los
+						cambios se reflejarán en tiempo real en el cotizador del sitio web.
 					</p>
-					{pricing.updatedAt ? (
+					{pricing.updatedAt && (
 						<p className="mt-3 text-xs text-slate-400">
 							Última actualización:{" "}
 							{new Date(pricing.updatedAt).toLocaleString()}
 						</p>
-					) : null}
+					)}
 				</header>
 
 				<form onSubmit={handleSubmit} className="space-y-10">
-					<section className="rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
-						<h2 className="text-xl font-semibold text-white">
-							Precio base por defecto
-						</h2>
-						<p className="mt-2 text-sm text-slate-300">
-							Define un precio base sugerido para tramos sin configuración
-							específica.
-						</p>
-						<div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
-							<label className="text-sm text-slate-300" htmlFor="basePrice">
-								Precio base (CLP)
-							</label>
-							<input
-								id="basePrice"
-								type="number"
-								min="0"
-								className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 sm:w-60"
-								value={pricing.basePrice}
-								onChange={handleBasePriceChange}
-							/>
-						</div>
-					</section>
-
 					<section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
-						<div className="flex flex-wrap items-center justify-between gap-4">
-							<div>
-								<h2 className="text-xl font-semibold text-white">
-									Promociones por tramo
-								</h2>
-								<p className="mt-2 text-sm text-slate-300">
-									Define tarifas especiales según origen/destino u otros
-									criterios.
-								</p>
-							</div>
-							<button
-								type="button"
-								onClick={addTramoPromotion}
-								className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60"
-							>
-								Añadir tramo
-							</button>
-						</div>
-
-						<div className="space-y-4">
-							{pricing.tramoPromotions.length === 0 ? (
-								<p className="text-sm text-slate-400">
-									Aún no has agregado promociones por tramo.
-								</p>
-							) : (
-								pricing.tramoPromotions.map((promo) => (
-									<div
-										key={promo.id}
-										className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
-									>
-										<div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4">
-											<label className="text-sm text-slate-300">
-												Nombre del tramo
-												<input
-													type="text"
-													value={promo.nombre || ""}
-													onChange={(event) =>
-														handleTramoChange(
-															promo.id,
-															"nombre",
-															event.target.value
-														)
-													}
-													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-												/>
-											</label>
-											<label className="text-sm text-slate-300">
-												Precio fijo (CLP)
+						<h2 className="text-xl font-semibold text-white">
+							Tarifas por Destino
+						</h2>
+						<div className="space-y-6">
+							{pricing.destinos.map((destino) => (
+								<div
+									key={destino.nombre}
+									className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
+								>
+									<h3 className="text-lg font-medium text-emerald-400">
+										{destino.nombre}
+									</h3>
+									<div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+										{Object.keys(destino.precios).map((vehiculo) => (
+											<label
+												key={vehiculo}
+												className="text-sm capitalize text-slate-300"
+											>
+												Precio Base ({vehiculo})
 												<input
 													type="number"
 													min="0"
-													value={promo.precio ?? 0}
-													onChange={(event) =>
-														handleTramoChange(
-															promo.id,
-															"precio",
-															Number(event.target.value)
+													value={destino.precios[vehiculo].base}
+													onChange={(e) =>
+														handleDestinoChange(
+															destino.nombre,
+															vehiculo,
+															"base",
+															e.target.value
 														)
 													}
 													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
 												/>
 											</label>
-											<label className="sm:col-span-2 text-sm text-slate-300">
-												Descripción u observaciones
-												<textarea
-													value={promo.descripcion || ""}
-													onChange={(event) =>
-														handleTramoChange(
-															promo.id,
-															"descripcion",
-															event.target.value
-														)
-													}
-													rows={2}
-													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-												/>
-											</label>
-										</div>
-										<div className="mt-4 flex justify-end">
-											<button
-												type="button"
-												onClick={() => removeTramoPromotion(promo.id)}
-												className="rounded-md border border-red-400 px-3 py-1 text-xs font-semibold text-red-200 transition hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/40"
-											>
-												Eliminar tramo
-											</button>
-										</div>
+										))}
 									</div>
-								))
-							)}
+								</div>
+							))}
 						</div>
 					</section>
 
@@ -332,11 +257,10 @@ function AdminPricing() {
 						<div className="flex flex-wrap items-center justify-between gap-4">
 							<div>
 								<h2 className="text-xl font-semibold text-white">
-									Promociones por día
+									Promociones por Día
 								</h2>
 								<p className="mt-2 text-sm text-slate-300">
-									Configura descuentos para días específicos de la semana o
-									rangos.
+									Configura descuentos para días específicos.
 								</p>
 							</div>
 							<button
@@ -344,130 +268,89 @@ function AdminPricing() {
 								onClick={addDayPromotion}
 								className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60"
 							>
-								Añadir promoción por día
+								Añadir Promoción
 							</button>
 						</div>
-
 						<div className="space-y-4">
-							{pricing.dayPromotions.length === 0 ? (
-								<p className="text-sm text-slate-400">
-									No existen promociones por día configuradas.
-								</p>
-							) : (
-								pricing.dayPromotions.map((promo) => (
-									<div
-										key={promo.id}
-										className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
-									>
-										<div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4">
-											<label className="text-sm text-slate-300">
-												Día o rango
-												<select
-													value={promo.dia || ""}
-													onChange={(event) =>
-														handleDayChange(promo.id, "dia", event.target.value)
-													}
-													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-												>
-													<option value="">Personalizado</option>
-													{daysOfWeek.map((day) => (
-														<option key={day} value={day}>
-															{day}
-														</option>
-													))}
-													<option value="Fin de semana">Fin de semana</option>
-													<option value="Feriados">Feriados</option>
-												</select>
-											</label>
-											<label className="text-sm text-slate-300">
-												Descuento (%)
-												<input
-													type="number"
-													min="0"
-													max="100"
-													value={promo.descuento ?? 0}
-													onChange={(event) =>
-														handleDayChange(
-															promo.id,
-															"descuento",
-															Number(event.target.value)
-														)
-													}
-													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-												/>
-											</label>
-											<label className="sm:col-span-2 text-sm text-slate-300">
-												Detalles de la promoción
-												<textarea
-													value={promo.descripcion || ""}
-													onChange={(event) =>
-														handleDayChange(
-															promo.id,
-															"descripcion",
-															event.target.value
-														)
-													}
-													rows={2}
-													className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-												/>
-											</label>
-										</div>
-										<div className="mt-4 flex justify-end">
+							{pricing.dayPromotions.map((promo) => (
+								<div
+									key={promo.id}
+									className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
+								>
+									<div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+										<label className="text-sm text-slate-300">
+											Día o Rango
+											<select
+												value={promo.dia || ""}
+												onChange={(e) =>
+													handleDayChange(promo.id, "dia", e.target.value)
+												}
+												className="mt-1 block w-full rounded-md border-slate-700 bg-slate-900 text-white"
+											>
+												{daysOfWeek.map((day) => (
+													<option key={day} value={day}>
+														{day}
+													</option>
+												))}
+											</select>
+										</label>
+										<label className="text-sm text-slate-300">
+											Descuento (%)
+											<input
+												type="number"
+												min="0"
+												max="100"
+												value={promo.descuento || 0}
+												onChange={(e) =>
+													handleDayChange(promo.id, "descuento", e.target.value)
+												}
+												className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white"
+											/>
+										</label>
+										<div className="flex items-end">
 											<button
 												type="button"
 												onClick={() => removeDayPromotion(promo.id)}
-												className="rounded-md border border-red-400 px-3 py-1 text-xs font-semibold text-red-200 transition hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/40"
+												className="w-full rounded-md border border-red-400/50 px-3 py-2 text-xs font-semibold text-red-200 transition hover:bg-red-500/10"
 											>
-												Eliminar promoción
+												Eliminar
 											</button>
 										</div>
 									</div>
-								))
-							)}
+								</div>
+							))}
 						</div>
 					</section>
 
 					<footer className="flex flex-col gap-4 border-t border-slate-800 pt-6 sm:flex-row sm:items-center sm:justify-between">
-						<div className="flex items-center gap-3 text-sm">
-							<button
-								type="button"
-								onClick={fetchPricing}
-								className="rounded-md border border-slate-700 px-4 py-2 text-sm font-medium text-slate-300 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
-								disabled={loading || saving}
-							>
-								Descartar cambios
-							</button>
-							<span className="text-xs text-slate-500">
-								Recarga la información desde el servidor
-							</span>
-						</div>
+						<button
+							type="button"
+							onClick={fetchPricing}
+							disabled={loading || saving}
+							className="rounded-md border border-slate-700 px-4 py-2 text-sm font-medium text-slate-300 transition hover:bg-slate-800"
+						>
+							Descartar Cambios
+						</button>
 						<button
 							type="submit"
 							disabled={saving || loading}
-							className="inline-flex items-center justify-center gap-2 rounded-md bg-emerald-500 px-6 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-500/60"
+							className="inline-flex items-center justify-center gap-2 rounded-md bg-emerald-500 px-6 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
 						>
-							{saving ? "Guardando..." : "Guardar cambios"}
+							{saving ? "Guardando..." : "Guardar Cambios"}
 						</button>
 					</footer>
 				</form>
 
-				{loading ? (
-					<div className="mt-6 rounded-md border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-300">
-						Cargando información de tarifas...
-					</div>
-				) : null}
-
-				{error ? (
+				{error && (
 					<div className="mt-6 rounded-md border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-200">
 						{error}
 					</div>
-				) : null}
-
-				{success ? (
+				)}
+				{success && (
 					<div className="mt-6 rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
 						{success}
 					</div>
-				) : null}
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/AdminPricing.jsx
+++ b/src/components/AdminPricing.jsx
@@ -1,0 +1,475 @@
+import { useCallback, useEffect, useState } from "react";
+
+const API_BASE_URL =
+        import.meta.env.VITE_API_URL || "https://transportes-araucaria.onrender.com";
+
+const createId = () => {
+        if (typeof crypto !== "undefined" && crypto.randomUUID) {
+                return crypto.randomUUID();
+        }
+        return `promo-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const defaultState = {
+        basePrice: 0,
+        tramoPromotions: [],
+        dayPromotions: [],
+        updatedAt: null,
+};
+
+const daysOfWeek = [
+        "Lunes",
+        "Martes",
+        "Miércoles",
+        "Jueves",
+        "Viernes",
+        "Sábado",
+        "Domingo",
+];
+
+function AdminPricing() {
+        const [pricing, setPricing] = useState(defaultState);
+        const [loading, setLoading] = useState(true);
+        const [saving, setSaving] = useState(false);
+        const [error, setError] = useState("");
+        const [success, setSuccess] = useState("");
+
+        const fetchPricing = useCallback(async () => {
+                setLoading(true);
+                setError("");
+                try {
+                        const response = await fetch(`${API_BASE_URL}/pricing`);
+                        if (!response.ok) {
+                                throw new Error("No se pudo obtener la configuración de precios.");
+                        }
+                        const data = await response.json();
+                        setPricing({
+                                basePrice: data.basePrice ?? 0,
+                                tramoPromotions: Array.isArray(data.tramoPromotions)
+                                        ? data.tramoPromotions
+                                        : [],
+                                dayPromotions: Array.isArray(data.dayPromotions)
+                                        ? data.dayPromotions
+                                        : [],
+                                updatedAt: data.updatedAt || null,
+                        });
+                } catch (fetchError) {
+                        console.error(fetchError);
+                        setError(
+                                fetchError.message ||
+                                        "Ocurrió un error inesperado al cargar la configuración."
+                        );
+                } finally {
+                        setLoading(false);
+                }
+        }, []);
+
+        useEffect(() => {
+                fetchPricing();
+        }, [fetchPricing]);
+
+        useEffect(() => {
+                if (!success) return;
+
+                const timeout = setTimeout(() => setSuccess(""), 4000);
+                return () => clearTimeout(timeout);
+        }, [success]);
+
+        const handleBasePriceChange = (event) => {
+                const value = Number(event.target.value);
+                setPricing((prev) => ({ ...prev, basePrice: Number.isNaN(value) ? 0 : value }));
+        };
+
+        const handleTramoChange = (id, field, value) => {
+                setPricing((prev) => ({
+                        ...prev,
+                        tramoPromotions: prev.tramoPromotions.map((promo) =>
+                                promo.id === id ? { ...promo, [field]: value } : promo
+                        ),
+                }));
+        };
+
+        const handleDayChange = (id, field, value) => {
+                setPricing((prev) => ({
+                        ...prev,
+                        dayPromotions: prev.dayPromotions.map((promo) =>
+                                promo.id === id ? { ...promo, [field]: value } : promo
+                        ),
+                }));
+        };
+
+        const addTramoPromotion = () => {
+                setPricing((prev) => ({
+                        ...prev,
+                        tramoPromotions: [
+                                ...prev.tramoPromotions,
+                                {
+                                        id: createId(),
+                                        nombre: "Nuevo tramo",
+                                        descripcion: "",
+                                        precio: prev.basePrice,
+                                },
+                        ],
+                }));
+        };
+
+        const addDayPromotion = () => {
+                setPricing((prev) => ({
+                        ...prev,
+                        dayPromotions: [
+                                ...prev.dayPromotions,
+                                {
+                                        id: createId(),
+                                        dia: "Lunes",
+                                        descripcion: "",
+                                        descuento: 0,
+                                },
+                        ],
+                }));
+        };
+
+        const removeTramoPromotion = (id) => {
+                setPricing((prev) => ({
+                        ...prev,
+                        tramoPromotions: prev.tramoPromotions.filter((promo) => promo.id !== id),
+                }));
+        };
+
+        const removeDayPromotion = (id) => {
+                setPricing((prev) => ({
+                        ...prev,
+                        dayPromotions: prev.dayPromotions.filter((promo) => promo.id !== id),
+                }));
+        };
+
+        const handleSubmit = async (event) => {
+                event.preventDefault();
+                setSaving(true);
+                setError("");
+                setSuccess("");
+
+                try {
+                        const response = await fetch(`${API_BASE_URL}/pricing`, {
+                                method: "PUT",
+                                headers: {
+                                        "Content-Type": "application/json",
+                                },
+                                body: JSON.stringify({
+                                        basePrice: Number(pricing.basePrice) || 0,
+                                        tramoPromotions: pricing.tramoPromotions.map((promo) => ({
+                                                ...promo,
+                                                precio: Number(promo.precio) || 0,
+                                        })),
+                                        dayPromotions: pricing.dayPromotions.map((promo) => ({
+                                                ...promo,
+                                                descuento: Number(promo.descuento) || 0,
+                                        })),
+                                }),
+                        });
+
+                        if (!response.ok) {
+                                const errorBody = await response.json().catch(() => ({}));
+                                const message =
+                                        errorBody?.message ||
+                                        "No se pudo guardar la configuración de precios.";
+                                throw new Error(message);
+                        }
+
+                        const saved = await response.json();
+                        setPricing(saved);
+                        setSuccess("Configuración guardada correctamente.");
+                } catch (submitError) {
+                        console.error(submitError);
+                        setError(submitError.message || "Ocurrió un error al guardar los cambios.");
+                } finally {
+                        setSaving(false);
+                }
+        };
+
+        return (
+                <div className="min-h-screen bg-slate-950 text-slate-100">
+                        <div className="mx-auto w-full max-w-5xl px-4 py-10">
+                                <header className="mb-10">
+                                        <h1 className="text-3xl font-semibold text-white">
+                                                Panel de tarifas y promociones
+                                        </h1>
+                                        <p className="mt-2 max-w-3xl text-sm text-slate-300">
+                                                Ajusta los valores base y administra promociones por tramo o por día.
+                                                Todos los cambios se guardan en el servidor para que puedan ser
+                                                consultados por otras herramientas o integraciones.
+                                        </p>
+                                        {pricing.updatedAt ? (
+                                                <p className="mt-3 text-xs text-slate-400">
+                                                        Última actualización: {" "}
+                                                        {new Date(pricing.updatedAt).toLocaleString()}
+                                                </p>
+                                        ) : null}
+                                </header>
+
+                                <form onSubmit={handleSubmit} className="space-y-10">
+                                        <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
+                                                <h2 className="text-xl font-semibold text-white">
+                                                        Precio base por defecto
+                                                </h2>
+                                                <p className="mt-2 text-sm text-slate-300">
+                                                        Define un precio base sugerido para tramos sin configuración
+                                                        específica.
+                                                </p>
+                                                <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+                                                        <label className="text-sm text-slate-300" htmlFor="basePrice">
+                                                                Precio base (CLP)
+                                                        </label>
+                                                        <input
+                                                                id="basePrice"
+                                                                type="number"
+                                                                min="0"
+                                                                className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 sm:w-60"
+                                                                value={pricing.basePrice}
+                                                                onChange={handleBasePriceChange}
+                                                        />
+                                                </div>
+                                        </section>
+
+                                        <section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
+                                                <div className="flex flex-wrap items-center justify-between gap-4">
+                                                        <div>
+                                                                <h2 className="text-xl font-semibold text-white">
+                                                                        Promociones por tramo
+                                                                </h2>
+                                                                <p className="mt-2 text-sm text-slate-300">
+                                                                        Define tarifas especiales según origen/destino u
+                                                                        otros criterios.
+                                                                </p>
+                                                        </div>
+                                                        <button
+                                                                type="button"
+                                                                onClick={addTramoPromotion}
+                                                                className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60"
+                                                        >
+                                                                Añadir tramo
+                                                        </button>
+                                                </div>
+
+                                                <div className="space-y-4">
+                                                        {pricing.tramoPromotions.length === 0 ? (
+                                                                <p className="text-sm text-slate-400">
+                                                                        Aún no has agregado promociones por tramo.
+                                                                </p>
+                                                        ) : (
+                                                                pricing.tramoPromotions.map((promo) => (
+                                                                        <div
+                                                                                key={promo.id}
+                                                                                className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
+                                                                        >
+                                                                                <div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4">
+                                                                                        <label className="text-sm text-slate-300">
+                                                                                                Nombre del tramo
+                                                                                                <input
+                                                                                                        type="text"
+                                                                                                        value={promo.nombre || ""}
+                                                                                                        onChange={(event) =>
+                                                                                                                handleTramoChange(
+                                                                                                                        promo.id,
+                                                                                                                        "nombre",
+                                                                                                                        event.target.value
+                                                                                                                )
+                                                                                                        }
+                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                                                                                                />
+                                                                                        </label>
+                                                                                        <label className="text-sm text-slate-300">
+                                                                                                Precio fijo (CLP)
+                                                                                                <input
+                                                                                                        type="number"
+                                                                                                        min="0"
+                                                                                                        value={promo.precio ?? 0}
+                                                                                                        onChange={(event) =>
+                                                                                                                handleTramoChange(
+                                                                                                                        promo.id,
+                                                                                                                        "precio",
+                                                                                                                        Number(event.target.value)
+                                                                                                                )
+                                                                                                        }
+                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                                                                                                />
+                                                                                        </label>
+                                                                                        <label className="sm:col-span-2 text-sm text-slate-300">
+                                                                                                Descripción u observaciones
+                                                                                                <textarea
+                                                                                                        value={promo.descripcion || ""}
+                                                                                                        onChange={(event) =>
+                                                                                                                handleTramoChange(
+                                                                                                                        promo.id,
+                                                                                                                        "descripcion",
+                                                                                                                        event.target.value
+                                                                                                                )
+                                                                                                        }
+                                                                                                        rows={2}
+                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                                                                                                />
+                                                                                        </label>
+                                                                                </div>
+                                                                                <div className="mt-4 flex justify-end">
+                                                                                        <button
+                                                                                                type="button"
+                                                                                                onClick={() => removeTramoPromotion(promo.id)}
+                                                                                                className="rounded-md border border-red-400 px-3 py-1 text-xs font-semibold text-red-200 transition hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/40"
+                                                                                        >
+                                                                                                Eliminar tramo
+                                                                                        </button>
+                                                                                </div>
+                                                                        </div>
+                                                                ))
+                                                        )}
+                                                </div>
+                                        </section>
+
+                                        <section className="space-y-6 rounded-lg border border-slate-800 bg-slate-900/70 p-6 shadow-lg">
+                                                <div className="flex flex-wrap items-center justify-between gap-4">
+                                                        <div>
+                                                                <h2 className="text-xl font-semibold text-white">
+                                                                        Promociones por día
+                                                                </h2>
+                                                                <p className="mt-2 text-sm text-slate-300">
+                                                                        Configura descuentos para días específicos de la semana o rangos.
+                                                                </p>
+                                                        </div>
+                                                        <button
+                                                                type="button"
+                                                                onClick={addDayPromotion}
+                                                                className="inline-flex items-center rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60"
+                                                        >
+                                                                Añadir promoción por día
+                                                        </button>
+                                                </div>
+
+                                                <div className="space-y-4">
+                                                        {pricing.dayPromotions.length === 0 ? (
+                                                                <p className="text-sm text-slate-400">
+                                                                        No existen promociones por día configuradas.
+                                                                </p>
+                                                        ) : (
+                                                                pricing.dayPromotions.map((promo) => (
+                                                                        <div
+                                                                                key={promo.id}
+                                                                                className="rounded-md border border-slate-800 bg-slate-950/60 p-4"
+                                                                        >
+                                                                                <div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4">
+                                                                                        <label className="text-sm text-slate-300">
+                                                                                                Día o rango
+                                                                                                <select
+                                                                                                        value={promo.dia || ""}
+                                                                                                        onChange={(event) =>
+                                                                                                                handleDayChange(
+                                                                                                                        promo.id,
+                                                                                                                        "dia",
+                                                                                                                        event.target.value
+                                                                                                                )
+                                                                                                        }
+                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                                                                                                >
+                                                                                                        <option value="">Personalizado</option>
+                                                                                                        {daysOfWeek.map((day) => (
+                                                                                                                <option key={day} value={day}>
+                                                                                                                        {day}
+                                                                                                                </option>
+                                                                                                        ))}
+                                                                                                        <option value="Fin de semana">Fin de semana</option>
+                                                                                                        <option value="Feriados">Feriados</option>
+                                                                                                </select>
+                                                                                        </label>
+                                                                                        <label className="text-sm text-slate-300">
+                                                                                                Descuento (%)
+                                                                                                <input
+                                                                                                        type="number"
+                                                                                                        min="0"
+                                                                                                        max="100"
+                                                                                                        value={promo.descuento ?? 0}
+                                                                                                        onChange={(event) =>
+                                                                                                                handleDayChange(
+                                                                                                                        promo.id,
+                                                                                                                        "descuento",
+                                                                                                                        Number(event.target.value)
+                                                                                                                )
+                                                                                                        }
+                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                                                                                                />
+                                                                                        </label>
+                                                                                        <label className="sm:col-span-2 text-sm text-slate-300">
+                                                                                                Detalles de la promoción
+                                                                                                <textarea
+                                                                                                        value={promo.descripcion || ""}
+                                                                                                        onChange={(event) =>
+                                                                                                                handleDayChange(
+                                                                                                                        promo.id,
+                                                                                                                        "descripcion",
+                                                                                                                        event.target.value
+                                                                                                                )
+                                                                                                        }
+                                                                                                        rows={2}
+                                                                                                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                                                                                                />
+                                                                                        </label>
+                                                                                </div>
+                                                                                <div className="mt-4 flex justify-end">
+                                                                                        <button
+                                                                                                type="button"
+                                                                                                onClick={() => removeDayPromotion(promo.id)}
+                                                                                                className="rounded-md border border-red-400 px-3 py-1 text-xs font-semibold text-red-200 transition hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500/40"
+                                                                                        >
+                                                                                                Eliminar promoción
+                                                                                        </button>
+                                                                                </div>
+                                                                        </div>
+                                                                ))
+                                                        )}
+                                                </div>
+                                        </section>
+
+                                        <footer className="flex flex-col gap-4 border-t border-slate-800 pt-6 sm:flex-row sm:items-center sm:justify-between">
+                                                <div className="flex items-center gap-3 text-sm">
+                                                        <button
+                                                                type="button"
+                                                                onClick={fetchPricing}
+                                                                className="rounded-md border border-slate-700 px-4 py-2 text-sm font-medium text-slate-300 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500/40"
+                                                                disabled={loading || saving}
+                                                        >
+                                                                Descartar cambios
+                                                        </button>
+                                                        <span className="text-xs text-slate-500">
+                                                                Recarga la información desde el servidor
+                                                        </span>
+                                                </div>
+                                                <button
+                                                        type="submit"
+                                                        disabled={saving || loading}
+                                                        className="inline-flex items-center justify-center gap-2 rounded-md bg-emerald-500 px-6 py-2 text-sm font-semibold text-slate-950 shadow transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-500/60"
+                                                >
+                                                        {saving ? "Guardando..." : "Guardar cambios"}
+                                                </button>
+                                        </footer>
+                                </form>
+
+                                {loading ? (
+                                        <div className="mt-6 rounded-md border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-300">
+                                                Cargando información de tarifas...
+                                        </div>
+                                ) : null}
+
+                                {error ? (
+                                        <div className="mt-6 rounded-md border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-200">
+                                                {error}
+                                        </div>
+                                ) : null}
+
+                                {success ? (
+                                        <div className="mt-6 rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
+                                                {success}
+                                        </div>
+                                ) : null}
+                        </div>
+                </div>
+        );
+}
+
+export default AdminPricing;

--- a/src/components/Contacto.jsx
+++ b/src/components/Contacto.jsx
@@ -11,6 +11,7 @@ import { Input } from "./ui/input";
 import { Textarea } from "./ui/textarea";
 import { Button } from "./ui/button";
 import { Phone, Mail, MapPin, Clock, LoaderCircle } from "lucide-react";
+import { Checkbox } from "./ui/checkbox";
 
 // Componente interno para reutilizar la lógica de mostrar información de contacto
 const InfoItem = ({ icon: Icon, title, children }) => (
@@ -34,6 +35,7 @@ function Contacto({
 	minDateTime,
 	phoneError,
 	isSubmitting,
+	setFormData,
 }) {
 	return (
 		<section id="contacto" className="py-24 bg-gray-50/50">
@@ -212,6 +214,66 @@ function Contacto({
 												required
 											/>
 										</div>
+									</div>
+									<div className="rounded-lg border border-muted/40 bg-muted/10 p-4 space-y-4">
+										<div className="flex items-start gap-3">
+											<Checkbox
+												id="ida-vuelta-form"
+												checked={formData.idaVuelta}
+												onCheckedChange={(value) => {
+													const isRoundTrip = Boolean(value);
+													setFormData((prev) => {
+														if (isRoundTrip) {
+															return {
+																...prev,
+																idaVuelta: true,
+																fechaRegreso: prev.fechaRegreso || prev.fecha,
+																horaRegreso: prev.horaRegreso,
+															};
+														}
+														return {
+															...prev,
+															idaVuelta: false,
+															fechaRegreso: "",
+															horaRegreso: "",
+														};
+													});
+											}}
+											/>
+											<label htmlFor="ida-vuelta-form" className="text-sm text-muted-foreground">
+												¿También necesitas coordinar el regreso?
+											</label>
+										</div>
+										{formData.idaVuelta && (
+											<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+												<div className="space-y-2">
+													<Label htmlFor="fecha-regreso-form">Fecha regreso</Label>
+													<Input
+														id="fecha-regreso-form"
+														type="date"
+														name="fechaRegreso"
+														min={formData.fecha || minDateTime}
+														value={formData.fechaRegreso}
+														onChange={handleInputChange}
+														required={formData.idaVuelta}
+													/>
+												</div>
+												<div className="space-y-2">
+													<Label htmlFor="hora-regreso-form">Hora regreso</Label>
+													<Input
+														id="hora-regreso-form"
+														type="time"
+														name="horaRegreso"
+														value={formData.horaRegreso}
+														onChange={handleInputChange}
+														required={formData.idaVuelta}
+													/>
+												</div>
+											</div>
+										)}
+										<p className="text-xs text-muted-foreground">
+											Coordinaremos ambos trayectos, te confirmaremos horarios y obtendrás un 5% adicional por reservar ida y vuelta.
+										</p>
 									</div>
 									<div className="space-y-2">
 										<Label htmlFor="pasajeros-form">N° de Pasajeros</Label>

--- a/src/components/Destinos.jsx
+++ b/src/components/Destinos.jsx
@@ -8,8 +8,10 @@ import {
 } from "./ui/card";
 import { Button } from "./ui/button";
 import { Clock, Plane, ArrowRight } from "lucide-react";
+import { destinosBase } from "@/data/destinos";
 
-function Destinos({ destinos }) {
+function Destinos() {
+	const destinos = destinosBase;
 	// Manejo por si no llegan destinos para evitar errores
 	if (!destinos || destinos.length === 0) {
 		return (

--- a/src/components/Destinos.jsx
+++ b/src/components/Destinos.jsx
@@ -10,6 +10,23 @@ import { Button } from "./ui/button";
 import { Clock, Plane, ArrowRight } from "lucide-react";
 
 function Destinos({ destinos }) {
+	// Manejo por si no llegan destinos para evitar errores
+	if (!destinos || destinos.length === 0) {
+		return (
+			<section id="destinos" className="py-20 bg-white">
+				<div className="container mx-auto px-4 text-center">
+					<h2 className="text-4xl font-bold mb-4 text-gray-800">
+						Principales Destinos
+					</h2>
+					<p className="text-xl text-muted-foreground">
+						Actualmente no hay destinos disponibles. Por favor, contacta para
+						más información.
+					</p>
+				</div>
+			</section>
+		);
+	}
+
 	return (
 		<section id="destinos" className="py-20 bg-white">
 			<div className="container mx-auto px-4">
@@ -23,7 +40,7 @@ function Destinos({ destinos }) {
 					</p>
 					<p className="text-sm text-muted-foreground max-w-2xl mx-auto mt-2">
 						Tarifas base para nuestro servicio exclusivo en auto (hasta 4
-						pasajeros).
+						pasajeros). Consulta en el cotizador para Vans.
 					</p>
 				</div>
 

--- a/src/data/destinos.jsx
+++ b/src/data/destinos.jsx
@@ -1,22 +1,45 @@
 // src/data/destinos.js
 
-// Importar imágenes
+// Importar imágenes de los destinos
 import temucoImg from "../assets/temuco.jpg";
 import villarricaImg from "../assets/villarrica.jpg";
 import puconImg from "../assets/pucon.jpg";
 import corralcoImg from "../assets/corralco.jpg";
 
-// Estructura base de destinos. Se exporta para ser usada en toda la aplicación.
+/**
+ * @typedef {object} PrecioVehiculo
+ * @property {number} base - El precio base para el servicio en este tipo de vehículo.
+ * @property {number} porcentajeAdicional - El porcentaje a añadir por cada pasajero adicional.
+ */
+
+/**
+ * @typedef {object} Destino
+ * @property {string} nombre - El nombre del destino.
+ * @property {string} descripcion - Una breve descripción para mostrar en la tarjeta del destino.
+ * @property {string} tiempo - Tiempo estimado de viaje desde el aeropuerto.
+ * @property {string} imagen - La imagen importada para el destino.
+ * @property {number} maxPasajeros - El número máximo de pasajeros permitido para este destino.
+ * @property {number} minHorasAnticipacion - Las horas mínimas de anticipación para reservar.
+ * @property {{auto: PrecioVehiculo, van?: PrecioVehiculo}} precios - Un objeto con los precios para cada tipo de vehículo.
+ */
+
+/**
+ * @type {Destino[]}
+ * Esta es la lista de destinos por defecto. Sirve como punto de partida si el servidor no responde
+ * o si el archivo de configuración en el servidor está vacío.
+ * El panel de administración te permitirá modificar, añadir o eliminar estos destinos dinámicamente.
+ */
 export const destinosBase = [
 	{
 		nombre: "Temuco",
 		descripcion: "Centro comercial y administrativo de La Araucanía.",
 		tiempo: "45 min",
 		imagen: temucoImg,
-		maxPasajeros: 4,
+		maxPasajeros: 7, // Habilitado para hasta 7 pasajeros
 		minHorasAnticipacion: 5,
 		precios: {
 			auto: { base: 20000, porcentajeAdicional: 0.1 },
+			van: { base: 45000, porcentajeAdicional: 0.1 }, // Precio base para la van en Temuco
 		},
 	},
 	{
@@ -45,14 +68,10 @@ export const destinosBase = [
 	},
 ];
 
-// Datos derivados que también se exportan para mantener la consistencia
-export const todosLosTramos = [
-	"Aeropuerto La Araucanía",
-	...destinosBase.map((d) => d.nombre),
-];
-
-export const origenesContacto = ["Aeropuerto La Araucanía", "Otro"];
-
+/**
+ * @type {object[]}
+ * Datos para la sección de destinos destacados o de temporada.
+ */
 export const destacadosData = [
 	{
 		nombre: "Corralco",

--- a/src/data/destinos.jsx
+++ b/src/data/destinos.jsx
@@ -1,0 +1,65 @@
+// src/data/destinos.js
+
+// Importar imágenes
+import temucoImg from "../assets/temuco.jpg";
+import villarricaImg from "../assets/villarrica.jpg";
+import puconImg from "../assets/pucon.jpg";
+import corralcoImg from "../assets/corralco.jpg";
+
+// Estructura base de destinos. Se exporta para ser usada en toda la aplicación.
+export const destinosBase = [
+	{
+		nombre: "Temuco",
+		descripcion: "Centro comercial y administrativo de La Araucanía.",
+		tiempo: "45 min",
+		imagen: temucoImg,
+		maxPasajeros: 4,
+		minHorasAnticipacion: 5,
+		precios: {
+			auto: { base: 20000, porcentajeAdicional: 0.1 },
+		},
+	},
+	{
+		nombre: "Villarrica",
+		descripcion: "Turismo y naturaleza junto al lago.",
+		tiempo: "1h 15min",
+		imagen: villarricaImg,
+		maxPasajeros: 7,
+		minHorasAnticipacion: 5,
+		precios: {
+			auto: { base: 55000, porcentajeAdicional: 0.05 },
+			van: { base: 200000, porcentajeAdicional: 0.05 },
+		},
+	},
+	{
+		nombre: "Pucón",
+		descripcion: "Aventura, termas y volcán.",
+		tiempo: "1h 30min",
+		imagen: puconImg,
+		maxPasajeros: 7,
+		minHorasAnticipacion: 5,
+		precios: {
+			auto: { base: 60000, porcentajeAdicional: 0.05 },
+			van: { base: 250000, porcentajeAdicional: 0.05 },
+		},
+	},
+];
+
+// Datos derivados que también se exportan para mantener la consistencia
+export const todosLosTramos = [
+	"Aeropuerto La Araucanía",
+	...destinosBase.map((d) => d.nombre),
+];
+
+export const origenesContacto = ["Aeropuerto La Araucanía", "Otro"];
+
+export const destacadosData = [
+	{
+		nombre: "Corralco",
+		titulo: "Visita Corralco en Temporada de Nieve",
+		subtitulo: "Una Aventura Invernal Inolvidable",
+		descripcion:
+			"Disfruta de la majestuosa nieve en el centro de ski Corralco, a los pies del volcán Lonquimay. Ofrecemos traslados directos y seguros para que solo te preocupes de disfrutar las pistas y los paisajes.",
+		imagen: corralcoImg,
+	},
+];

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global __dirname */
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";


### PR DESCRIPTION
## Summary
- add persistent pricing configuration endpoints to the Express backend so tariffs can be read and updated
- seed the repository with a default pricing dataset for tramo and day promotions
- create an admin panel at `/admin/precios` that allows editing the base price and promotions and writing the changes back to the API

## Testing
- pnpm run build
- pnpm run lint *(fails: existing unused `Icon` imports in Contacto.jsx, Footer.jsx, Tours.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d7de7443b083289b180b0fd9b4cce7